### PR TITLE
Use obsidian.json if vaultpath preference is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ dist
 .tern-port
 
 .DS_Store
+
+# JetBrains
+.idea

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ This command will open a list of your pinned notes. All actions and preferences 
 
 ### General settings
 
-- set path/paths to your vault/vaults (comma separated)
+- set path/paths to your preferred vault/vaults (comma separated).
+  By default, vaults will be detected from `~/Library/Application Support/obsidian/obsidian.json`, which contains all vaults that have been opened with Obsidian before.
 
 ### Search Note
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
       "type": "textfield",
       "placeholder": "path/to/vault",
       "title": "Path to Vault",
-      "required": true,
+      "required": false,
       "description": "Specify the path or multiple paths (comma separated) to your vault/vaults"
     }
   ],

--- a/src/components/NoVaultFoundMessage.tsx
+++ b/src/components/NoVaultFoundMessage.tsx
@@ -1,0 +1,7 @@
+import { Detail } from "@raycast/api";
+
+
+export function NoVaultFoundMessage() {
+  const text = "# No vaults found\n\n Please use Obsidian to create a vault, or set a vault path in the extension's preferences before using this command.";
+  return <Detail markdown={text} />;
+}

--- a/src/createNoteCommand.tsx
+++ b/src/createNoteCommand.tsx
@@ -1,13 +1,16 @@
-import { showToast, Toast } from "@raycast/api";
+import { List, showToast, Toast } from "@raycast/api";
 
 import { CreateNoteForm } from "./components/CreateNoteForm";
 import { VaultSelection } from "./components/VaultSelection";
 import { Vault } from "./utils/interfaces";
-import { parseVaults } from "./utils/utils";
+import { useObsidianVaults } from "./utils/utils";
 
 export default function Command() {
-  const vaults = parseVaults();
-  if (vaults.length > 1) {
+  const { vaults, ready } = useObsidianVaults();
+
+  if (!ready) {
+    return <List isLoading={true}></List>
+  } else if (vaults.length > 1) {
     return <VaultSelection vaults={vaults} target={(vault: Vault) => <CreateNoteForm vaultPath={vault.path} />} />;
   } else if (vaults.length == 1) {
     return <CreateNoteForm vaultPath={vaults[0].path} />;

--- a/src/createNoteCommand.tsx
+++ b/src/createNoteCommand.tsx
@@ -4,12 +4,15 @@ import { CreateNoteForm } from "./components/CreateNoteForm";
 import { VaultSelection } from "./components/VaultSelection";
 import { Vault } from "./utils/interfaces";
 import { useObsidianVaults } from "./utils/utils";
+import { NoVaultFoundMessage } from "./components/NoVaultFoundMessage";
 
 export default function Command() {
   const { vaults, ready } = useObsidianVaults();
 
   if (!ready) {
-    return <List isLoading={true}></List>
+    return <List isLoading={true}></List>;
+  } else if (vaults.length === 0) {
+    return <NoVaultFoundMessage></NoVaultFoundMessage>
   } else if (vaults.length > 1) {
     return <VaultSelection vaults={vaults} target={(vault: Vault) => <CreateNoteForm vaultPath={vault.path} />} />;
   } else if (vaults.length == 1) {

--- a/src/dailyNoteCommand.tsx
+++ b/src/dailyNoteCommand.tsx
@@ -2,6 +2,7 @@ import { Action, ActionPanel, closeMainWindow, Detail, List, open, popToRoot, sh
 
 import { Vault } from "./utils/interfaces";
 import { useObsidianVaults, vaultPluginCheck } from "./utils/utils";
+import { NoVaultFoundMessage } from "./components/NoVaultFoundMessage";
 
 const getTarget = (vaultName: string) => {
   return "obsidian://advanced-uri?vault=" + encodeURIComponent(vaultName) + "&daily=true";
@@ -11,7 +12,9 @@ export default function Command() {
   const { vaults, ready } = useObsidianVaults();
 
   if (!ready) {
-    return <List isLoading={true}></List>
+    return <List isLoading={true}></List>;
+  } else if (vaults.length === 0) {
+    return <NoVaultFoundMessage />;
   }
 
   const [vaultsWithPlugin, vaultsWithoutPlugin] = vaultPluginCheck(vaults, "obsidian-advanced-uri");

--- a/src/dailyNoteCommand.tsx
+++ b/src/dailyNoteCommand.tsx
@@ -1,14 +1,18 @@
-import { List, ActionPanel, Action, Detail, showToast, Toast, closeMainWindow, open, popToRoot } from "@raycast/api";
+import { Action, ActionPanel, closeMainWindow, Detail, List, open, popToRoot, showToast, Toast } from "@raycast/api";
 
 import { Vault } from "./utils/interfaces";
-import { vaultPluginCheck, parseVaults } from "./utils/utils";
+import { useObsidianVaults, vaultPluginCheck } from "./utils/utils";
 
 const getTarget = (vaultName: string) => {
   return "obsidian://advanced-uri?vault=" + encodeURIComponent(vaultName) + "&daily=true";
 };
 
 export default function Command() {
-  const vaults = parseVaults();
+  const { vaults, ready } = useObsidianVaults();
+
+  if (!ready) {
+    return <List isLoading={true}></List>
+  }
 
   const [vaultsWithPlugin, vaultsWithoutPlugin] = vaultPluginCheck(vaults, "obsidian-advanced-uri");
 

--- a/src/openVaultCommand.tsx
+++ b/src/openVaultCommand.tsx
@@ -1,22 +1,22 @@
-import { List, ActionPanel, Action, open, popToRoot, closeMainWindow } from "@raycast/api";
+import { Action, ActionPanel, closeMainWindow, List, open, popToRoot } from "@raycast/api";
 
-import { parseVaults } from "./utils/utils";
+import { useObsidianVaults } from "./utils/utils";
 
 const getTarget = (vaultName: string) => {
   return "obsidian://open?vault=" + encodeURIComponent(vaultName);
 };
 
 export default function Command() {
-  const vaults = parseVaults();
+  const { ready, vaults } = useObsidianVaults();
 
-  if (vaults.length == 1) {
+  if (vaults.length === 1) {
     open(getTarget(vaults[0].name));
     popToRoot();
     closeMainWindow();
   }
 
   return (
-    <List isLoading={vaults === undefined}>
+    <List isLoading={!ready}>
       {vaults?.map((vault) => (
         <List.Item
           title={vault.name}

--- a/src/openVaultCommand.tsx
+++ b/src/openVaultCommand.tsx
@@ -1,6 +1,7 @@
-import { Action, ActionPanel, closeMainWindow, List, open, popToRoot } from "@raycast/api";
+import { Action, ActionPanel, closeMainWindow, List, open, popToRoot, showToast, Toast } from "@raycast/api";
 
 import { useObsidianVaults } from "./utils/utils";
+import { NoVaultFoundMessage } from "./components/NoVaultFoundMessage";
 
 const getTarget = (vaultName: string) => {
   return "obsidian://open?vault=" + encodeURIComponent(vaultName);
@@ -15,19 +16,37 @@ export default function Command() {
     closeMainWindow();
   }
 
-  return (
-    <List isLoading={!ready}>
-      {vaults?.map((vault) => (
-        <List.Item
-          title={vault.name}
-          key={vault.key}
-          actions={
-            <ActionPanel>
-              <Action.Open title="Open vault" target={getTarget(vault.name)} />
-            </ActionPanel>
-          }
-        />
-      ))}
-    </List>
-  );
+  if (!ready) {
+    return <List isLoading={true}></List>;
+  } else if (vaults.length === 0) {
+    return <NoVaultFoundMessage />;
+  } else if (vaults.length == 1) {
+    open(getTarget(vaults[0].name));
+    popToRoot();
+    closeMainWindow();
+    return <List />;
+  } else if (vaults.length > 1) {
+    return (
+      <List isLoading={!ready}>
+        {vaults?.map((vault) => (
+          <List.Item
+            title={vault.name}
+            key={vault.key}
+            actions={
+              <ActionPanel>
+                <Action.Open title="Open vault" target={getTarget(vault.name)} />
+              </ActionPanel>
+            }
+          />
+        ))}
+      </List>
+    );
+  } else {
+    showToast({
+      title: "Path Error",
+      message: "Something went wrong with your vault path. There are no paths to select from.",
+      style: Toast.Style.Failure,
+    });
+    return <List />;
+  }
 }

--- a/src/pinnedNotesCommand.tsx
+++ b/src/pinnedNotesCommand.tsx
@@ -1,13 +1,16 @@
-import { showToast, Toast } from "@raycast/api";
+import { List, showToast, Toast } from "@raycast/api";
 
-import { parseVaults } from "./utils/utils";
+import { useObsidianVaults } from "./utils/utils";
 import { VaultSelection } from "./components/VaultSelection";
 import { Vault } from "./utils/interfaces";
 import { NoteListPinned } from "./components/NoteListPinned";
 
 export default function Command() {
-  const vaults = parseVaults();
-  if (vaults.length > 1) {
+  const { vaults, ready } = useObsidianVaults();
+
+  if (!ready) {
+    return <List isLoading={true}></List>
+  } else if (vaults.length > 1) {
     return <VaultSelection vaults={vaults} target={(vault: Vault) => <NoteListPinned vaultPath={vault.path} />} />;
   } else if (vaults.length == 1) {
     return <NoteListPinned vaultPath={vaults[0].path} />;

--- a/src/pinnedNotesCommand.tsx
+++ b/src/pinnedNotesCommand.tsx
@@ -4,12 +4,15 @@ import { useObsidianVaults } from "./utils/utils";
 import { VaultSelection } from "./components/VaultSelection";
 import { Vault } from "./utils/interfaces";
 import { NoteListPinned } from "./components/NoteListPinned";
+import { NoVaultFoundMessage } from "./components/NoVaultFoundMessage";
 
 export default function Command() {
   const { vaults, ready } = useObsidianVaults();
 
   if (!ready) {
-    return <List isLoading={true}></List>
+    return <List isLoading={true}></List>;
+  } else if (vaults.length === 0) {
+    return <NoVaultFoundMessage />;
   } else if (vaults.length > 1) {
     return <VaultSelection vaults={vaults} target={(vault: Vault) => <NoteListPinned vaultPath={vault.path} />} />;
   } else if (vaults.length == 1) {
@@ -20,5 +23,6 @@ export default function Command() {
       message: "Something went wrong with your vault path. There are no paths to select from.",
       style: Toast.Style.Failure,
     });
+    return <List />;
   }
 }

--- a/src/searchNoteCommand.tsx
+++ b/src/searchNoteCommand.tsx
@@ -4,12 +4,15 @@ import { useObsidianVaults } from "./utils/utils";
 import { NoteListObsidian } from "./components/NoteListObsidian";
 import { VaultSelection } from "./components/VaultSelection";
 import { Vault } from "./utils/interfaces";
+import { NoVaultFoundMessage } from "./components/NoVaultFoundMessage";
 
 export default function Command() {
   const { ready, vaults } = useObsidianVaults();
 
   if (!ready) {
-    return <List isLoading={true}></List>
+    return <List isLoading={true}></List>;
+  } else if (vaults.length === 0) {
+    return <NoVaultFoundMessage />;
   } else if (vaults.length > 1) {
     return <VaultSelection vaults={vaults} target={(vault: Vault) => <NoteListObsidian vaultPath={vault.path} />} />;
   } else if (vaults.length == 1) {
@@ -18,7 +21,7 @@ export default function Command() {
     showToast({
       title: "Path Error",
       message: "Something went wrong with your vault path. There are no paths to select from.",
-      style: Toast.Style.Failure,
+      style: Toast.Style.Failure
     });
   }
 }

--- a/src/searchNoteCommand.tsx
+++ b/src/searchNoteCommand.tsx
@@ -1,13 +1,16 @@
-import { showToast, Toast } from "@raycast/api";
+import { List, showToast, Toast } from "@raycast/api";
 
-import { parseVaults } from "./utils/utils";
+import { useObsidianVaults } from "./utils/utils";
 import { NoteListObsidian } from "./components/NoteListObsidian";
 import { VaultSelection } from "./components/VaultSelection";
 import { Vault } from "./utils/interfaces";
 
 export default function Command() {
-  const vaults = parseVaults();
-  if (vaults.length > 1) {
+  const { ready, vaults } = useObsidianVaults();
+
+  if (!ready) {
+    return <List isLoading={true}></List>
+  } else if (vaults.length > 1) {
     return <VaultSelection vaults={vaults} target={(vault: Vault) => <NoteListObsidian vaultPath={vault.path} />} />;
   } else if (vaults.length == 1) {
     return <NoteListObsidian vaultPath={vaults[0].path} />;

--- a/src/utils/interfaces.tsx
+++ b/src/utils/interfaces.tsx
@@ -39,3 +39,18 @@ export interface Note {
   key: number;
   path: string;
 }
+
+interface ObsidianJsonVault {
+  path: string,
+  ts: number,
+  open: boolean
+}
+
+export interface ObsidianJson {
+  vaults: Record<string, ObsidianJsonVault>;
+}
+
+export interface ObsidianVaultsState {
+  ready: boolean;
+  vaults: Vault[];
+}

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -90,17 +90,21 @@ export function parseVaults(): Vault[] {
   const pref: Preferences = getPreferenceValues();
   const vaultString = pref.vaultPath;
   return vaultString
-    ?.split(",")
+    .split(",")
     .map((vault) => ({ name: getVaultNameFromPath(vault.trim()), key: vault.trim(), path: vault.trim() }))
     .filter((vault) => !!vault) ?? [];
 }
 
 async function loadObsidianJson(): Promise<Vault[]> {
   const obsidianJsonPath = fsPath.resolve(`${homedir()}/Library/Application Support/obsidian/obsidian.json`);
-  const obsidianJson = JSON.parse(await readFile(obsidianJsonPath, "utf8")) as ObsidianJson;
-  return Object.values(obsidianJson.vaults).map(({ path }) => ({
-    name: getVaultNameFromPath(path), key: path, path
-  }));
+  try {
+    const obsidianJson = JSON.parse(await readFile(obsidianJsonPath, "utf8")) as ObsidianJson;
+    return Object.values(obsidianJson.vaults).map(({ path }) => ({
+      name: getVaultNameFromPath(path), key: path, path
+    }));
+  } catch (e) {
+    return [];
+  }
 }
 
 export function useObsidianVaults(): ObsidianVaultsState {

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -91,8 +91,8 @@ export function parseVaults(): Vault[] {
   const vaultString = pref.vaultPath;
   return vaultString
     .split(",")
+    .filter((vaultPath) => vaultPath.trim() !== '')
     .map((vault) => ({ name: getVaultNameFromPath(vault.trim()), key: vault.trim(), path: vault.trim() }))
-    .filter((vault) => !!vault) ?? [];
 }
 
 async function loadObsidianJson(): Promise<Vault[]> {

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -1,9 +1,19 @@
 import { getPreferenceValues } from "@raycast/api";
 
 import fs from "fs";
-import path from "path";
+import fsPath from "path";
 
-import { Note, Vault, SearchNotePreferences, Preferences } from "../utils/interfaces";
+import {
+  Note,
+  ObsidianJson,
+  ObsidianVaultsState,
+  Preferences,
+  SearchNotePreferences,
+  Vault
+} from "../utils/interfaces";
+import { readFile } from "fs/promises";
+import { homedir } from "os";
+import { useEffect, useMemo, useState } from "react";
 
 export function getNoteContent(note: Note) {
   const pref: SearchNotePreferences = getPreferenceValues();
@@ -62,7 +72,7 @@ export function vaultPluginCheck(vaults: Vault[], plugin: string) {
 
 function getVaultNameFromPath(vaultPath: string): string {
   const name = vaultPath
-    .split(path.sep)
+    .split(fsPath.sep)
     .filter((i) => {
       if (i != "") {
         return i;
@@ -76,11 +86,37 @@ function getVaultNameFromPath(vaultPath: string): string {
   }
 }
 
-export function parseVaults() {
+export function parseVaults(): Vault[] {
   const pref: Preferences = getPreferenceValues();
   const vaultString = pref.vaultPath;
   return vaultString
-    .split(",")
+    ?.split(",")
     .map((vault) => ({ name: getVaultNameFromPath(vault.trim()), key: vault.trim(), path: vault.trim() }))
-    .filter((vault) => !!vault);
+    .filter((vault) => !!vault) ?? [];
+}
+
+async function loadObsidianJson(): Promise<Vault[]> {
+  const obsidianJsonPath = fsPath.resolve(`${homedir()}/Library/Application Support/obsidian/obsidian.json`);
+  const obsidianJson = JSON.parse(await readFile(obsidianJsonPath, "utf8")) as ObsidianJson;
+  return Object.values(obsidianJson.vaults).map(({ path }) => ({
+    name: getVaultNameFromPath(path), key: path, path
+  }));
+}
+
+export function useObsidianVaults(): ObsidianVaultsState {
+  const pref = useMemo(() => getPreferenceValues(), []);
+  const [state, setState] = useState<ObsidianVaultsState>(pref.vaultPath ? {
+    ready: true,
+    vaults: parseVaults()
+  } : { ready: false, vaults: [] });
+
+  useEffect(() => {
+    if (!state.ready) {
+      loadObsidianJson().then((vaults) => {
+        setState({ vaults, ready: true });
+      }).catch(() => setState({ vaults: parseVaults(), ready: true }));
+    }
+  }, []);
+
+  return state;
 }


### PR DESCRIPTION
- Makes the vaultpath preference optional
- Opens and loads vaults from `obsidian.json` file
- Shows "loading list" while vaults are loading (to wait for async file read)
- If vaultpath is present, it is preferred over `obsidian.json`

Closes #18 