### PR TITLE
Add "Append to Daily Note" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This is a raycast extension with commands for the note taking and knowledge mana
 - [Open Vault](https://github.com/marcjulianschwarz/obsidian-raycast#open-vault)
 - [Create Note](https://github.com/marcjulianschwarz/obsidian-raycast#create-note)
 - [Daily Note](https://github.com/marcjulianschwarz/obsidian-raycast#daily-note)
+- [Append to Daily Note](https://github.com/marcjulianschwarz/obsidian-raycast#append-to-daily-note)
 - [Pinned Note](https://github.com/marcjulianschwarz/obsidian-raycast#pinned-notes)
 - [Obsidian Menu Bar Item](https://github.com/marcjulianschwarz/obsidian-raycast#obsidian-menu-bar-item)
 
@@ -125,6 +126,12 @@ Both the note name and note content support these templates:
 This command will open the daily note from the selected vault. If a daily note doesn't exist it will create one and open it.
 It requires the community plugin [Advanced Obsidian URI](https://obsidian.md/plugins?id=obsidian-advanced-uri) and the core plugin "Daily notes" to be installed and enabled.
 
+## Append to Daily Note
+
+This command will append text to the daily note from the selected vault. If a daily note doesn't exist it will create one and open it. To append as efficiently as possible, the text is provided as a parameter to the command, so there's no form to fill out.
+
+It requires the community plugin [Advanced Obsidian URI](https://obsidian.md/plugins?id=obsidian-advanced-uri) and the core plugin "Daily notes" to be installed and enabled.
+
 ## Pinned Notes
 
 This command will open a list of your pinned notes. All actions and preferences from the `Search Note` command are available.
@@ -171,6 +178,12 @@ Clicking it will reveal a list of your vaults. You can view your pinned notes, p
 - default note content
 - fill form with default values
 - list of folders that will create actions for creating notes inside of the specified folders
+
+### Append to Daily Note
+
+- template for the appended text (e.g. could set to `- [ ] ` to create a checklist item)
+- vault in which the Daily Note will be appended (if not set, the last open vault will be used)
+- heading in which the appended text will be placed (if not set, the text will be appended to the end of the note)
 
 ### Pinned Notes
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Clicking it will reveal a list of your vaults. You can view your pinned notes, p
 ### Append to Daily Note
 
 - template for the appended text (e.g. could set to `- [ ] ` to create a checklist item)
-- vault in which the Daily Note will be appended (if not set, the last open vault will be used)
+- vault in which the Daily Note will be appended (if not set, you will be prompted to select a vault when the command is run)
 - heading in which the appended text will be placed (if not set, the text will be appended to the end of the note)
 
 ### Pinned Notes

--- a/package.json
+++ b/package.json
@@ -143,6 +143,44 @@
       "mode": "view"
     },
     {
+      "name": "dailyNoteAppendCommand",
+      "title": "Append to Daily Note",
+      "subtitle": "Obsidian",
+      "description": "Append text to your daily note",
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "text",
+          "placeholder": "Take out the trash",
+          "type": "text",
+          "required": true
+        }
+      ],
+      "preferences": [
+        {
+          "name": "appendTemplate",
+          "type": "textfield",
+          "title": "Template for Daily Note Append action",
+          "required": false,
+          "description": "Specify a template for Daily Note Append action (e.g. '- {content}')"
+        },
+        {
+          "name": "vault",
+          "type": "textfield",
+          "title": "Name of Obsidian vault where note is",
+          "required": false,
+          "description": "Name of Obsidian vault where note is"
+        },
+        {
+          "name": "heading",
+          "type": "textfield",
+          "title": "Name of heading in note in which to append",
+          "required": false,
+          "description": "If no heading is set, text will be appended to the end of the daily note"
+        }
+      ]
+    },
+    {
       "name": "dailyNoteCommand",
       "title": "Daily Note",
       "subtitle": "Obsidian",

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
           "description": "Specify a template for Daily Note Append action (e.g. '- {content}')"
         },
         {
-          "name": "vault",
+          "name": "vaultName",
           "type": "textfield",
           "title": "Name of Obsidian vault where note is",
           "required": false,

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
       "title": "Append to Daily Note",
       "subtitle": "Obsidian",
       "description": "Append text to your daily note",
-      "mode": "no-view",
+      "mode": "view",
       "arguments": [
         {
           "name": "text",

--- a/src/components/AdvancedURIPluginNotInstalled.tsx
+++ b/src/components/AdvancedURIPluginNotInstalled.tsx
@@ -1,0 +1,8 @@
+import { Detail } from "@raycast/api";
+
+export default function AdvancedURIPluginNotInstalled({ vaultName }: { vaultName?: string }) {
+  const vaultText = vaultName ? `vault "${vaultName}"` : "any vault";
+  const text = `# Advanced URI plugin not installed in ${vaultText}.\nThis command requires the [Advanced URI plugin](https://obsidian.md/plugins?id=obsidian-advanced-uri) for Obsidian.  \n  \n Install it through the community plugins list.`;
+
+  return <Detail navigationTitle="Advanced URI plugin not installed" markdown={text} />;
+}

--- a/src/components/Toasts.tsx
+++ b/src/components/Toasts.tsx
@@ -1,5 +1,5 @@
 import { showToast, Toast } from "@raycast/api";
-import { Note } from "../utils/interfaces";
+import { Note, Vault } from "../utils/interfaces";
 
 //--------------------------------------------------------------------------------
 // All toasts for all commands should be defined here.
@@ -51,5 +51,13 @@ export function noteUnpinnedToast(note: Note) {
     title: "Note Unpinned",
     message: "'" + note.title + "' unpinned successfully.",
     style: Toast.Style.Success,
+  });
+}
+
+export function vaultsWithoutAdvancedURIToast(vaultsWithoutPlugin: Vault[]) {
+  showToast({
+    title: "Vaults without Advanced URI plugin:",
+    message: vaultsWithoutPlugin.map((vault: Vault) => vault.name).join(", "),
+    style: Toast.Style.Failure,
   });
 }

--- a/src/dailyNoteAppendCommand.tsx
+++ b/src/dailyNoteAppendCommand.tsx
@@ -1,6 +1,9 @@
-import { getPreferenceValues, open, showToast, Toast } from "@raycast/api";
-import { URLSearchParams } from "url";
-import { applyTemplates, loadObsidianJson, vaultPluginCheck } from "./utils/utils";
+import { Action, ActionPanel, closeMainWindow, Detail, getPreferenceValues, List, open, popToRoot } from "@raycast/api";
+import { useEffect, useState } from "react";
+import AdvancedURIPluginNotInstalled from "./components/AdvancedURIPluginNotInstalled";
+import { NoVaultFoundMessage } from "./components/NoVaultFoundMessage";
+import { vaultsWithoutAdvancedURIToast } from "./components/Toasts";
+import { applyTemplates, getDailyNoteAppendTarget, useObsidianVaults, vaultPluginCheck } from "./utils/utils";
 
 interface DailyNoteAppendArgs {
   text: string;
@@ -12,62 +15,64 @@ interface Preferences {
   heading?: string;
 }
 
-export default async function DailyNoteAppend(props: { arguments: DailyNoteAppendArgs }) {
+export default function DailyNoteAppend(props: { arguments: DailyNoteAppendArgs }) {
+  const { vaults, ready } = useObsidianVaults();
   const { text } = props.arguments;
   const { appendTemplate, heading, vaultName } = getPreferenceValues<Preferences>();
+  const [vaultsWithPlugin, vaultsWithoutPlugin] = vaultPluginCheck(vaults, "obsidian-advanced-uri");
+  const [content, setContent] = useState("");
+  useEffect(() => {
+    async function getContent() {
+      const withTemplate = appendTemplate ? appendTemplate + text : text;
+      const content = await applyTemplates(withTemplate);
+      setContent(content);
+    }
+    getContent();
+  }, []);
 
-  const vaults = await loadObsidianJson();
-  if (vaults.length === 0) {
-    return showToast({
-      style: Toast.Style.Failure,
-      title: "No vaults found",
-      message:
-        "Please use Obsidian to create a vault, or set a vault path in the extension's preferences before using this command.",
-    });
+  if (!ready || !content) {
+    return <List isLoading={true}></List>;
+  } else if (vaults.length === 0) {
+    return <NoVaultFoundMessage />;
   }
 
-  const [vaultsWithPlugin, _] = vaultPluginCheck(vaults, "obsidian-advanced-uri");
-
+  if (vaultsWithoutPlugin.length > 0) {
+    vaultsWithoutAdvancedURIToast(vaultsWithoutPlugin);
+  }
+  if (vaultsWithPlugin.length == 0) {
+    return <AdvancedURIPluginNotInstalled />;
+  }
   if (vaultName) {
     // Fail if selected vault doesn't have plugin
     if (!vaultsWithPlugin.some((v) => v.name === vaultName)) {
-      return showToast({
-        style: Toast.Style.Failure,
-        title: "Advanced URI plugin not found in vault",
-        message: `Vault ${vaultName} is missing the Advanced URI plugin`,
-      });
+      return <AdvancedURIPluginNotInstalled vaultName={vaultName} />;
     }
   }
 
-  // Fail if there's no selected vault, and no vaults have the plugin
-  if (vaultsWithPlugin.length == 0) {
-    const message =
-      "Advanced URI plugin not installed.\nThis command requires the [Advanced URI plugin](https://obsidian.md/plugins?id=obsidian-advanced-uri) for Obsidian.  \n  \n Install it through the community plugins list.";
-    return await showToast({
-      title: "Advanced URI plugin required",
-      message,
-    });
+  const selectedVault = vaultName && vaults.find((vault) => vault.name === vaultName);
+  // If there's a configured vault, or only one vault, use that
+  if (selectedVault || vaultsWithPlugin.length == 1) {
+    const vaultToUse = selectedVault || vaultsWithPlugin[0];
+    const uri = getDailyNoteAppendTarget(vaultToUse, content, heading);
+    open(uri);
+    popToRoot();
+    closeMainWindow();
   }
 
-  // Use configured vault, fallback to first vault with plugin
-  const configuredVault = vaults.find((vault) => vault.name === vaultName);
-  const vaultToUse = configuredVault || vaultsWithPlugin[0];
-
-  const withTemplate = appendTemplate ? appendTemplate + text : text;
-  const content = await applyTemplates(withTemplate);
-  // encodeURIComponent to avoid replacing spaces with +
-  const data = encodeURIComponent(content);
-  const params = new URLSearchParams({
-    daily: "true",
-    data,
-    mode: "append",
-    vault: vaultToUse.name,
-  });
-  if (heading) {
-    params.append("heading", heading);
-  }
-  const uri = `obsidian://advanced-uri?${params}`;
-  open(uri);
-
-  showToast({ title: "Added text to note", style: Toast.Style.Success });
+  // Otherwise let the user select a vault
+  return (
+    <List isLoading={vaultsWithPlugin === undefined}>
+      {vaultsWithPlugin?.map((vault) => (
+        <List.Item
+          title={vault.name}
+          key={vault.key}
+          actions={
+            <ActionPanel>
+              <Action.Open title="Append to Daily Note" target={getDailyNoteAppendTarget(vault, content, heading)} />
+            </ActionPanel>
+          }
+        />
+      ))}
+    </List>
+  );
 }

--- a/src/dailyNoteAppendCommand.tsx
+++ b/src/dailyNoteAppendCommand.tsx
@@ -1,0 +1,38 @@
+import { getPreferenceValues, open, Detail, showToast, Toast, useNavigation } from "@raycast/api";
+import { URLSearchParams } from "url";
+import { applyTemplates } from "./utils/utils";
+
+interface QuickAppendArgs {
+  text: string;
+}
+
+interface Preferences {
+  appendTemplate?: string;
+  vault?: string;
+  heading?: string;
+}
+
+export default async function DailyNoteAppend(props: { arguments: QuickAppendArgs }) {
+  const { text } = props.arguments;
+  const { appendTemplate, heading, vault } = getPreferenceValues<Preferences>();
+
+  const withTemplate = appendTemplate ? appendTemplate + text : text;
+  const content = await applyTemplates(withTemplate);
+  // encodeURIComponent to avoid replacing spaces with +
+  const data = encodeURIComponent(content);
+  const params = new URLSearchParams({
+    daily: "true",
+    data,
+    mode: "append",
+  });
+  if (heading) {
+    params.append("heading", heading);
+  }
+  if (vault) {
+    params.append("vault", vault);
+  }
+  const uri = `obsidian://advanced-uri?${params}`;
+  open(uri);
+
+  showToast({ title: "Added text to note", style: Toast.Style.Success });
+}

--- a/src/dailyNoteAppendCommand.tsx
+++ b/src/dailyNoteAppendCommand.tsx
@@ -2,7 +2,7 @@ import { getPreferenceValues, open, showToast, Toast } from "@raycast/api";
 import { URLSearchParams } from "url";
 import { applyTemplates, loadObsidianJson, vaultPluginCheck } from "./utils/utils";
 
-interface QuickAppendArgs {
+interface DailyNoteAppendArgs {
   text: string;
 }
 
@@ -12,7 +12,7 @@ interface Preferences {
   heading?: string;
 }
 
-export default async function DailyNoteAppend(props: { arguments: QuickAppendArgs }) {
+export default async function DailyNoteAppend(props: { arguments: DailyNoteAppendArgs }) {
   const { text } = props.arguments;
   const { appendTemplate, heading, vaultName } = getPreferenceValues<Preferences>();
 

--- a/src/dailyNoteCommand.tsx
+++ b/src/dailyNoteCommand.tsx
@@ -3,6 +3,8 @@ import { Action, ActionPanel, closeMainWindow, Detail, List, open, popToRoot, sh
 import { Vault } from "./utils/interfaces";
 import { getDailyNoteTarget, useObsidianVaults, vaultPluginCheck } from "./utils/utils";
 import { NoVaultFoundMessage } from "./components/NoVaultFoundMessage";
+import { vaultsWithoutAdvancedURIToast } from "./components/Toasts";
+import AdvancedURIPluginNotInstalled from "./components/AdvancedURIPluginNotInstalled";
 
 export default function Command() {
   const { vaults, ready } = useObsidianVaults();
@@ -16,18 +18,10 @@ export default function Command() {
   const [vaultsWithPlugin, vaultsWithoutPlugin] = vaultPluginCheck(vaults, "obsidian-advanced-uri");
 
   if (vaultsWithoutPlugin.length > 0) {
-    showToast({
-      title: "Vaults without Daily Note plugin:",
-      message: vaultsWithoutPlugin.map((vault: Vault) => vault.name).join(", "),
-      style: Toast.Style.Failure,
-    });
+    vaultsWithoutAdvancedURIToast(vaultsWithoutPlugin);
   }
-
   if (vaultsWithPlugin.length == 0) {
-    const text =
-      "# Advanced URI plugin not installed.\nThis command requires the [Advanced URI plugin](https://obsidian.md/plugins?id=obsidian-advanced-uri) for Obsidian.  \n  \n Install it through the community plugins list.";
-
-    return <Detail navigationTitle="Advanced URI plugin not installed" markdown={text} />;
+    return <AdvancedURIPluginNotInstalled />;
   }
 
   if (vaultsWithPlugin.length == 1) {

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -128,7 +128,7 @@ export function parseVaults(): Vault[] {
     .map((vault) => ({ name: getVaultNameFromPath(vault.trim()), key: vault.trim(), path: vault.trim() }));
 }
 
-async function loadObsidianJson(): Promise<Vault[]> {
+export async function loadObsidianJson(): Promise<Vault[]> {
   const obsidianJsonPath = fsPath.resolve(`${homedir()}/Library/Application Support/obsidian/obsidian.json`);
   try {
     const obsidianJson = JSON.parse(await readFile(obsidianJsonPath, "utf8")) as ObsidianJSON;

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -40,6 +40,7 @@ import {
 import { isNotePinned, unpinNote } from "./pinNoteUtils";
 import { useNotes } from "./cache";
 import { MediaLoader } from "./loader";
+import { URLSearchParams } from "url";
 
 export function getCodeBlocks(content: string): CodeBlock[] {
   const codeBlockMatches = content.matchAll(CODE_BLOCK_REGEX);
@@ -128,7 +129,7 @@ export function parseVaults(): Vault[] {
     .map((vault) => ({ name: getVaultNameFromPath(vault.trim()), key: vault.trim(), path: vault.trim() }));
 }
 
-export async function loadObsidianJson(): Promise<Vault[]> {
+async function loadObsidianJson(): Promise<Vault[]> {
   const obsidianJsonPath = fsPath.resolve(`${homedir()}/Library/Application Support/obsidian/obsidian.json`);
   try {
     const obsidianJson = JSON.parse(await readFile(obsidianJsonPath, "utf8")) as ObsidianJSON;
@@ -304,6 +305,21 @@ export const getOpenPathInObsidianTarget = (path: string) => {
 
 export const getDailyNoteTarget = (vault: Vault) => {
   return "obsidian://advanced-uri?vault=" + encodeURIComponent(vault.name) + "&daily=true";
+};
+
+export const getDailyNoteAppendTarget = (vault: Vault, text: string, heading: string | undefined) => {
+  // encodeURIComponent to avoid replacing spaces with +
+  const data = encodeURIComponent(text);
+  const params = new URLSearchParams({
+    daily: "true",
+    data,
+    mode: "append",
+    vault: vault.name,
+  });
+  if (heading) {
+    params.append("heading", heading);
+  }
+  return `obsidian://advanced-uri?${params}`;
 };
 
 export function getListOfExtensions(media: Media[]) {

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -308,18 +308,15 @@ export const getDailyNoteTarget = (vault: Vault) => {
 };
 
 export const getDailyNoteAppendTarget = (vault: Vault, text: string, heading: string | undefined) => {
-  // encodeURIComponent to avoid replacing spaces with +
-  const data = encodeURIComponent(text);
-  const params = new URLSearchParams({
-    daily: "true",
-    data,
-    mode: "append",
-    vault: vault.name,
-  });
-  if (heading) {
-    params.append("heading", heading);
-  }
-  return `obsidian://advanced-uri?${params}`;
+  const headingParam = heading ? "&heading=" + encodeURIComponent(heading) : "";
+  return (
+    "obsidian://advanced-uri?daily=true&mode=append" +
+    "&data=" +
+    encodeURIComponent(text) +
+    "&vault=" +
+    encodeURIComponent(vault.name) +
+    headingParam
+  );
 };
 
 export function getListOfExtensions(media: Media[]) {


### PR DESCRIPTION
Closes https://github.com/marcjulianschwarz/obsidian-raycast/issues/31

TODO:
- [x] Use your fancier vaults logic? (vaultPluginCheck, useObsidianVaults)
  - Done in baea1f9568a209933c30f416e5ebf8440526e359
- [x] Update README
  - Done in 1b28afbcef7220176ccaede52066e6e02c3abaf0

I've been putting TODOs in my daily note, so I would use this with a template of `- [ ] ` and a heading preference of `TODO` to append a task to my TODO heading.

I have this mapped to a `td` alias, so it's very quick to append:
- Launch raycast
- Type `td` + space/tab
- Type the todo
- Enter
- Done!