### PR TITLE
search .canvas files

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     ],
     "contributes": [
         "iancanderson",
-        "mikejongbloet"
+        "mikejongbloet",
+        "sapoepsilon"
     ],
     "license": "MIT",
     "preferences": [{

--- a/src/utils/data/loader.tsx
+++ b/src/utils/data/loader.tsx
@@ -67,7 +67,7 @@ export class NoteLoader {
     const exFolders = prefExcludedFolders();
     const userIgnoredFolders = getUserIgnoreFilters(this.vault);
     exFolders.push(...userIgnoredFolders);
-    const files = walkFilesHelper(this.vault.path, exFolders, [".md"], []);
+    const files = walkFilesHelper(this.vault.path, exFolders, [".md", ".canvas"], []);
     return files;
   }
 }


### PR DESCRIPTION
Added `.canvas` files to search filter

<img width="773" alt="image" src="https://user-images.githubusercontent.com/47342870/233849366-b8411556-d372-46df-aedf-2887c025b1d8.png">


@marcjulianschwarz  I have a question; right now, the search can display raw JSON contents of the .canvas file. I would like to know if showing a `.canvas` file like in Obsidian is better. It requires a lot of front-end work. So, I am torn on this. I am looking for your feedback. 

