### PR TITLE
feature/refactor-note-loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ dist
 
 # JetBrains
 .idea
+
+# Custom
+playground/

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "lunr": "^2.3.9",
         "luxon": "^3.4.4",
         "minimatch": "^10.0.3",
+        "minisearch": "^7.2.0",
+        "pako": "^2.1.0",
         "uuid": "^8.3.2",
         "yaml": "^2.1.1"
       },
@@ -22,6 +24,7 @@
         "@types/lunr": "^2.3.7",
         "@types/luxon": "^3.4.2",
         "@types/node": "^22.14.1",
+        "@types/pako": "^2.0.4",
         "@types/react": "^19.0.3",
         "eslint": "^8.42.0",
         "prettier": "^2.8.8",
@@ -813,6 +816,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.0.3",
@@ -2775,6 +2785,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2891,6 +2907,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,6 @@
         "lunr": "^2.3.9",
         "luxon": "^3.4.4",
         "minimatch": "^10.0.3",
-        "minisearch": "^7.1.2",
-        "pako": "^2.1.0",
         "uuid": "^8.3.2",
         "yaml": "^2.1.1"
       },
@@ -25,85 +23,16 @@
         "@types/luxon": "^3.4.2",
         "@types/node": "^22.14.1",
         "@types/react": "^19.0.3",
-        "@types/pako": "^2.0.3",
-        "@types/react": "^17.0.52",
         "eslint": "^8.42.0",
         "prettier": "^2.8.8",
         "typescript": "^5.6.3",
         "vitest": "^3.1.1"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
-      "integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.3.tgz",
-      "integrity": "sha512-PuwVXbnP87Tcff5I9ngV0lmiSu40xw1At6i3GsU77U7cjDDB4s0X2cyFuBiDa1SBk9DnvWwnGvVaGBqoFWPb7A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.3.tgz",
-      "integrity": "sha512-XelR6MzjlZuBM4f5z2IQHK6LkK34Cvv6Rj2EntER3lwCBFdg6h2lKbtRjpTTsdEjD/WSe1q8UyPBXP1x3i/wYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.3.tgz",
-      "integrity": "sha512-ogtTpYHT/g1GWS/zKM0cc/tIebFjm1F9Aw1boQ2Y0eUQ+J89d0jFY//s9ei9jVIlkYi8AfOjiixcLJSGNSOAdQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.3",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.3.tgz",
       "integrity": "sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==",
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.3.tgz",
-      "integrity": "sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==",
       "cpu": [
         "arm64"
       ],
@@ -111,326 +40,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz",
-      "integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.3.tgz",
-      "integrity": "sha512-EJiyS70BYybOBpJth3M0KLOus0n+RRMKTYzhYhFeMwp7e/RaajXvP+BWlmEXNk6uk+KAu46j/kaQzr6au+JcIw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.3.tgz",
-      "integrity": "sha512-Q+wSjaLpGxYf7zC0kL0nDlhsfuFkoN+EXrx2KSB33RhinWzejOd6AvgmP5JbkgXKmjhmpfgKZq24pneodYqE8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.3.tgz",
-      "integrity": "sha512-dUOVmAUzuHy2ZOKIHIKHCm58HKzFqd+puLaS424h6I85GlSDRZIA5ycBixb3mFgM0Jdh+ZOSB6KptX30DD8YOQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.3.tgz",
-      "integrity": "sha512-xCUgnNYhRD5bb1C1nqrDV1PfkwgbswTTBRbAd8aH5PhYzikdf/ddtsYyMXFfGSsb/6t6QaPSzxtbfAZr9uox4A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.3.tgz",
-      "integrity": "sha512-yplPOpczHOO4jTYKmuYuANI3WhvIPSVANGcNUeMlxH4twz/TeXuzEP41tGKNGWJjuMhotpGabeFYGAOU2ummBw==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.3.tgz",
-      "integrity": "sha512-P4BLP5/fjyihmXCELRGrLd793q/lBtKMQl8ARGpDxgzgIKJDRJ/u4r1A/HgpBpKpKZelGct2PGI4T+axcedf6g==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.3.tgz",
-      "integrity": "sha512-eRAOV2ODpu6P5divMEMa26RRqb2yUoYsuQQOuFUexUoQndm4MdpXXDBbUoKIc0iPa4aCO7gIhtnYomkn2x+bag==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.3.tgz",
-      "integrity": "sha512-ZC4jV2p7VbzTlnl8nZKLcBkfzIf4Yad1SJM4ZMKYnJqZFD4rTI+pBG65u8ev4jk3/MPwY9DvGn50wi3uhdaghg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.3.tgz",
-      "integrity": "sha512-LDDODcFzNtECTrUUbVCs6j9/bDVqy7DDRsuIXJg6so+mFksgwG7ZVnTruYi5V+z3eE5y+BJZw7VvUadkbfg7QA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.3.tgz",
-      "integrity": "sha512-s+w/NOY2k0yC2p9SLen+ymflgcpRkvwwa02fqmAwhBRI3SC12uiS10edHHXlVWwfAagYSY5UpmT/zISXPMW3tQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.3.tgz",
-      "integrity": "sha512-nQHDz4pXjSDC6UfOE1Fw9Q8d6GCAd9KdvMZpfVGWSJztYCarRgSDfOVBY5xwhQXseiyxapkiSJi/5/ja8mRFFA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.3.tgz",
-      "integrity": "sha512-1QaLtOWq0mzK6tzzp0jRN3eccmN3hezey7mhLnzC6oNlJoUJz4nym5ZD7mDnS/LZQgkrhEbEiTn515lPeLpgWA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.3.tgz",
-      "integrity": "sha512-i5Hm68HXHdgv8wkrt+10Bc50zM0/eonPb/a/OFVfB6Qvpiirco5gBA5bz7S2SHuU+Y4LWn/zehzNX14Sp4r27g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.3.tgz",
-      "integrity": "sha512-zGAVApJEYTbOC6H/3QBr2mq3upG/LBEXr85/pTtKiv2IXcgKV0RT0QA/hSXZqSvLEpXeIxah7LczB4lkiYhTAQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.3.tgz",
-      "integrity": "sha512-fpqctI45NnCIDKBH5AXQBsD0NDPbEFczK98hk/aa6HJxbl+UtLkJV2+Bvy5hLSLk3LHmqt0NTkKNso1A9y1a4w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.3.tgz",
-      "integrity": "sha512-ROJhm7d8bk9dMCUZjkS8fgzsPAZEjtRJqCAmVgB0gMrvG7hfmPmz9k1rwO4jSiblFjYmNvbECL9uhaPzONMfgA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.3.tgz",
-      "integrity": "sha512-YWcow8peiHpNBiIXHwaswPnAXLsLVygFwCB3A7Bh5jRkIBFWHGmNQ48AlX4xDvQNoMZlPYzjVOQDYEzWCqufMQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.3.tgz",
-      "integrity": "sha512-qspTZOIGoXVS4DpNqUYUs9UxVb04khS1Degaw/MnfMe7goQ3lTfQ13Vw4qY/Nj0979BGvMRpAYbs/BAxEvU8ew==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.3.tgz",
-      "integrity": "sha512-ICgUR+kPimx0vvRzf+N/7L7tVSQeE3BYY+NhHRHXS1kBuPO7z2+7ea2HbhDyZdTephgvNvKrlDDKUexuCVBVvg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -493,9 +102,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -546,9 +152,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -592,7 +195,6 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@inquirer/checkbox": {
-    "node_modules/@inquirer/checkbox": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.5.tgz",
       "integrity": "sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ==",
@@ -617,7 +219,6 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-    "node_modules/@inquirer/confirm": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.9.tgz",
       "integrity": "sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==",
@@ -638,7 +239,6 @@
         }
       }
     },
-    "node_modules/@inquirer/core": {
     "node_modules/@inquirer/core": {
       "version": "10.1.10",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
@@ -681,21 +281,6 @@
       }
     },
     "node_modules/@inquirer/editor": {
-    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@inquirer/editor": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.10.tgz",
       "integrity": "sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw==",
@@ -718,7 +303,6 @@
       }
     },
     "node_modules/@inquirer/expand": {
-    "node_modules/@inquirer/expand": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.12.tgz",
       "integrity": "sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw==",
@@ -740,16 +324,6 @@
         }
       }
     },
-    "node_modules/@inquirer/figures": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
-      "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/input": {
     "node_modules/@inquirer/figures": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
@@ -802,7 +376,6 @@
       }
     },
     "node_modules/@inquirer/password": {
-    "node_modules/@inquirer/password": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.12.tgz",
       "integrity": "sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g==",
@@ -828,10 +401,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.5.0.tgz",
       "integrity": "sha512-tk8Bx7l5AX/CR0sVfGj3Xg6v7cYlFBkEahH+EgBB+cZib6Fc83dwerTbzj7f2+qKckjIUGsviWRI1d7lx6nqQA==",
-    "node_modules/@inquirer/prompts": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.5.0.tgz",
-      "integrity": "sha512-tk8Bx7l5AX/CR0sVfGj3Xg6v7cYlFBkEahH+EgBB+cZib6Fc83dwerTbzj7f2+qKckjIUGsviWRI1d7lx6nqQA==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/checkbox": "^4.1.5",
@@ -842,9 +411,7 @@
         "@inquirer/number": "^3.0.12",
         "@inquirer/password": "^4.0.12",
         "@inquirer/rawlist": "^4.1.0",
-        "@inquirer/rawlist": "^4.1.0",
         "@inquirer/search": "^3.0.12",
-        "@inquirer/select": "^4.2.0"
         "@inquirer/select": "^4.2.0"
       },
       "engines": {
@@ -859,10 +426,6 @@
         }
       }
     },
-    "node_modules/@inquirer/rawlist": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.0.tgz",
-      "integrity": "sha512-6ob45Oh9pXmfprKqUiEeMz/tjtVTFQTgDDz1xAMKMrIvyrYjAmRbQZjMJfsictlL4phgjLhdLu27IkHNnNjB7g==",
     "node_modules/@inquirer/rawlist": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.0.tgz",
@@ -885,7 +448,6 @@
         }
       }
     },
-    "node_modules/@inquirer/search": {
     "node_modules/@inquirer/search": {
       "version": "3.0.12",
       "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.12.tgz",
@@ -913,10 +475,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.0.tgz",
       "integrity": "sha512-KkXQ4aSySWimpV4V/TUJWdB3tdfENZUU765GjOIZ0uPwdbGIG6jrxD4dDf1w68uP+DVtfNhr1A92B+0mbTZ8FA==",
-    "node_modules/@inquirer/select": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.0.tgz",
-      "integrity": "sha512-KkXQ4aSySWimpV4V/TUJWdB3tdfENZUU765GjOIZ0uPwdbGIG6jrxD4dDf1w68uP+DVtfNhr1A92B+0mbTZ8FA==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.10",
@@ -937,7 +495,6 @@
         }
       }
     },
-    "node_modules/@inquirer/type": {
     "node_modules/@inquirer/type": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.6.tgz",
@@ -968,22 +525,9 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
       "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "license": "MIT",
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
       },
       "engines": {
         "node": "20 || >=22"
@@ -1115,106 +659,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@oclif/core": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.2.10.tgz",
-      "integrity": "sha512-fAqcXgqkUm4v5FYy7qWP4w1HaOlVSVJveah+yVTo5Nm5kTiXhmD5mQQ7+knGeBaStyrtQy6WardoC2xSic9rlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^4.3.2",
-        "ansis": "^3.17.0",
-        "clean-stack": "^3.0.1",
-        "cli-spinners": "^2.9.2",
-        "debug": "^4.4.0",
-        "ejs": "^3.1.10",
-        "get-package-type": "^0.1.0",
-        "globby": "^11.1.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "lilconfig": "^3.1.3",
-        "minimatch": "^9.0.5",
-        "semver": "^7.6.3",
-        "string-width": "^4.2.3",
-        "supports-color": "^8",
-        "widest-line": "^3.1.0",
-        "wordwrap": "^1.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@oclif/plugin-autocomplete": {
-      "version": "3.2.27",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.27.tgz",
-      "integrity": "sha512-Aywx0Vw36k0fQVBa2uLb8FKblGAP7ly1cQ5bdKqL4BmhJnUasy37tpyIDMUor93asOS+kKFQg+52pOxQgXHi1A==",
-      "license": "MIT",
-      "dependencies": {
-        "@oclif/core": "^4",
-        "ansis": "^3.16.0",
-        "debug": "^4.4.0",
-        "ejs": "^3.1.10"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@oclif/plugin-help": {
-      "version": "6.2.27",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.27.tgz",
-      "integrity": "sha512-RWSWtCFVObRmCwgxVOye3lsYbPHTnB7G4He5LEAg2tf600Sil5yXEOL/ULx1TqL/XOQxKqRvmLn/rLQOMT85YA==",
-      "license": "MIT",
-      "dependencies": {
-        "@oclif/core": "^4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@oclif/plugin-not-found": {
-      "version": "3.2.49",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.49.tgz",
-      "integrity": "sha512-3V74/O5aFAqTTCJ7+X04M6vmt59Dk8HimB2uOlGgJrR7yLMW9JsVWKpDZZ6fl1hfd5kK9Jn4oaEt/1LuwfW1wQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/prompts": "^7.4.1",
-        "@oclif/core": "^4",
-        "ansis": "^3.17.0",
-        "fast-levenshtein": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.96.1",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.96.1.tgz",
-      "integrity": "sha512-TVtKEPuoGWQiaHTJlbwxgelsclb0U8ALLyw0IeIOcFa83fafkJih+RwSVJx7iP6CF4edssFzMwYkhca0rrpk7A==",
       "version": "1.96.1",
       "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.96.1.tgz",
       "integrity": "sha512-TVtKEPuoGWQiaHTJlbwxgelsclb0U8ALLyw0IeIOcFa83fafkJih+RwSVJx7iP6CF4edssFzMwYkhca0rrpk7A==",
@@ -1361,28 +808,11 @@
       "version": "22.15.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.2.tgz",
       "integrity": "sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==",
-      "version": "22.15.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.2.tgz",
-      "integrity": "sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/pako": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.3.tgz",
-      "integrity": "sha512-bq0hMV9opAcrmE0Byyo0fY3Ew4tgOevJmQ9grUhpXQhYfyLJ1Kqg3P33JT5fdbT2AjeAjR51zqqVjAL/HMkx7Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.0.3",
@@ -1763,14 +1193,9 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.2.tgz",
       "integrity": "sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==",
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.2.tgz",
-      "integrity": "sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.2",
-        "@vitest/utils": "3.1.2",
         "@vitest/spy": "3.1.2",
         "@vitest/utils": "3.1.2",
         "chai": "^5.2.0",
@@ -1784,13 +1209,9 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.2.tgz",
       "integrity": "sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==",
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.2.tgz",
-      "integrity": "sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.2",
         "@vitest/spy": "3.1.2",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
@@ -1815,9 +1236,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
       "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
-      "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1831,13 +1249,9 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.2.tgz",
       "integrity": "sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==",
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.2.tgz",
-      "integrity": "sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.1.2",
         "@vitest/utils": "3.1.2",
         "pathe": "^2.0.3"
       },
@@ -1849,13 +1263,9 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.2.tgz",
       "integrity": "sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==",
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.2.tgz",
-      "integrity": "sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.2",
         "@vitest/pretty-format": "3.1.2",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
@@ -1865,9 +1275,6 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.2.tgz",
-      "integrity": "sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==",
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.2.tgz",
       "integrity": "sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==",
@@ -1884,13 +1291,9 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
       "integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
-      "integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.2",
         "@vitest/pretty-format": "3.1.2",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
@@ -2308,31 +1711,6 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.3",
-        "@esbuild/android-arm": "0.25.3",
-        "@esbuild/android-arm64": "0.25.3",
-        "@esbuild/android-x64": "0.25.3",
-        "@esbuild/darwin-arm64": "0.25.3",
-        "@esbuild/darwin-x64": "0.25.3",
-        "@esbuild/freebsd-arm64": "0.25.3",
-        "@esbuild/freebsd-x64": "0.25.3",
-        "@esbuild/linux-arm": "0.25.3",
-        "@esbuild/linux-arm64": "0.25.3",
-        "@esbuild/linux-ia32": "0.25.3",
-        "@esbuild/linux-loong64": "0.25.3",
-        "@esbuild/linux-mips64el": "0.25.3",
-        "@esbuild/linux-ppc64": "0.25.3",
-        "@esbuild/linux-riscv64": "0.25.3",
-        "@esbuild/linux-s390x": "0.25.3",
-        "@esbuild/linux-x64": "0.25.3",
-        "@esbuild/netbsd-arm64": "0.25.3",
-        "@esbuild/netbsd-x64": "0.25.3",
-        "@esbuild/openbsd-arm64": "0.25.3",
-        "@esbuild/openbsd-x64": "0.25.3",
-        "@esbuild/sunos-x64": "0.25.3",
-        "@esbuild/win32-arm64": "0.25.3",
-        "@esbuild/win32-ia32": "0.25.3",
-        "@esbuild/win32-x64": "0.25.3"
         "@esbuild/aix-ppc64": "0.25.3",
         "@esbuild/android-arm": "0.25.3",
         "@esbuild/android-arm64": "0.25.3",
@@ -2896,9 +2274,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3211,9 +2586,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3403,12 +2775,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minisearch": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.1.2.tgz",
-      "integrity": "sha512-R1Pd9eF+MD5JYDDSPAp/q1ougKglm14uEkPMvQ/05RGmx6G9wvmLTrTI/Q5iPNJLYqNdsDQ7qTGIcNWR+FrHmA==",
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3525,12 +2891,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -4018,7 +3378,6 @@
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.4.4",
-        "fdir": "^6.4.4",
         "picomatch": "^4.0.2"
       },
       "engines": {
@@ -4029,9 +3388,6 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
-      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
       "version": "6.4.4",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
       "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
@@ -4218,19 +3574,14 @@
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
-        "fdir": "^6.4.4",
         "picomatch": "^4.0.2",
         "postcss": "^8.5.3",
         "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
         "tinyglobby": "^0.2.13"
       },
       "bin": {
@@ -4298,9 +3649,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.2.tgz",
       "integrity": "sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==",
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.2.tgz",
-      "integrity": "sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4321,9 +3669,6 @@
       }
     },
     "node_modules/vite/node_modules/fdir": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
-      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
       "version": "6.4.4",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
       "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
@@ -4355,9 +3700,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.2.tgz",
       "integrity": "sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==",
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.2.tgz",
-      "integrity": "sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4368,29 +3710,18 @@
         "@vitest/snapshot": "3.1.2",
         "@vitest/spy": "3.1.2",
         "@vitest/utils": "3.1.2",
-        "@vitest/expect": "3.1.2",
-        "@vitest/mocker": "3.1.2",
-        "@vitest/pretty-format": "^3.1.2",
-        "@vitest/runner": "3.1.2",
-        "@vitest/snapshot": "3.1.2",
-        "@vitest/spy": "3.1.2",
-        "@vitest/utils": "3.1.2",
         "chai": "^5.2.0",
         "debug": "^4.4.0",
-        "expect-type": "^1.2.1",
         "expect-type": "^1.2.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
         "std-env": "^3.9.0",
-        "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.13",
         "tinyglobby": "^0.2.13",
         "tinypool": "^1.0.2",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.1.2",
         "vite-node": "3.1.2",
         "why-is-node-running": "^2.3.0"
       },
@@ -4407,8 +3738,6 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.1.2",
-        "@vitest/ui": "3.1.2",
         "@vitest/browser": "3.1.2",
         "@vitest/ui": "3.1.2",
         "happy-dom": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
         "@raycast/api": "^1.94.0",
         "@types/uuid": "^8.3.4",
         "fuse.js": "^7.0.0",
+        "gray-matter": "^4.0.3",
+        "lunr": "^2.3.9",
         "luxon": "^3.4.4",
+        "minimatch": "^10.0.3",
         "minisearch": "^7.1.2",
         "pako": "^2.1.0",
         "uuid": "^8.3.2",
@@ -18,20 +21,22 @@
       },
       "devDependencies": {
         "@raycast/eslint-config": "^1.0.6",
+        "@types/lunr": "^2.3.7",
         "@types/luxon": "^3.4.2",
         "@types/node": "^22.14.1",
+        "@types/react": "^19.0.3",
         "@types/pako": "^2.0.3",
         "@types/react": "^17.0.52",
         "eslint": "^8.42.0",
         "prettier": "^2.8.8",
-        "typescript": "^4.5.4",
+        "typescript": "^5.6.3",
         "vitest": "^3.1.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.3.tgz",
-      "integrity": "sha512-W8bFfPA8DowP8l//sxjJLSLkD8iEjMc7cBVyP+u4cEv9sM7mdUCkgsj+t0n/BWPFtv7WWCN5Yzj0N6FJNUUqBQ==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
+      "integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
       "cpu": [
         "ppc64"
       ],
@@ -96,6 +101,9 @@
       "version": "0.25.3",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.3.tgz",
       "integrity": "sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.3.tgz",
+      "integrity": "sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==",
       "cpu": [
         "arm64"
       ],
@@ -109,9 +117,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.3.tgz",
-      "integrity": "sha512-Kd8glo7sIZtwOLcPbW0yLpKmBNWMANZhrC1r6K++uDR2zyzb6AeOYtI6udbtabmQpFaxJ8uduXMAo1gs5ozz8A==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz",
+      "integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
       "cpu": [
         "x64"
       ],
@@ -485,6 +493,9 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -535,6 +546,9 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -578,6 +592,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@inquirer/checkbox": {
+    "node_modules/@inquirer/checkbox": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.5.tgz",
       "integrity": "sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ==",
@@ -602,6 +617,7 @@
       }
     },
     "node_modules/@inquirer/confirm": {
+    "node_modules/@inquirer/confirm": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.9.tgz",
       "integrity": "sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==",
@@ -622,6 +638,7 @@
         }
       }
     },
+    "node_modules/@inquirer/core": {
     "node_modules/@inquirer/core": {
       "version": "10.1.10",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
@@ -664,6 +681,21 @@
       }
     },
     "node_modules/@inquirer/editor": {
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/editor": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.10.tgz",
       "integrity": "sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw==",
@@ -686,6 +718,7 @@
       }
     },
     "node_modules/@inquirer/expand": {
+    "node_modules/@inquirer/expand": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.12.tgz",
       "integrity": "sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw==",
@@ -707,6 +740,16 @@
         }
       }
     },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+      "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
     "node_modules/@inquirer/figures": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
@@ -759,6 +802,7 @@
       }
     },
     "node_modules/@inquirer/password": {
+    "node_modules/@inquirer/password": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.12.tgz",
       "integrity": "sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g==",
@@ -784,6 +828,10 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.5.0.tgz",
       "integrity": "sha512-tk8Bx7l5AX/CR0sVfGj3Xg6v7cYlFBkEahH+EgBB+cZib6Fc83dwerTbzj7f2+qKckjIUGsviWRI1d7lx6nqQA==",
+    "node_modules/@inquirer/prompts": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.5.0.tgz",
+      "integrity": "sha512-tk8Bx7l5AX/CR0sVfGj3Xg6v7cYlFBkEahH+EgBB+cZib6Fc83dwerTbzj7f2+qKckjIUGsviWRI1d7lx6nqQA==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/checkbox": "^4.1.5",
@@ -794,7 +842,9 @@
         "@inquirer/number": "^3.0.12",
         "@inquirer/password": "^4.0.12",
         "@inquirer/rawlist": "^4.1.0",
+        "@inquirer/rawlist": "^4.1.0",
         "@inquirer/search": "^3.0.12",
+        "@inquirer/select": "^4.2.0"
         "@inquirer/select": "^4.2.0"
       },
       "engines": {
@@ -809,6 +859,10 @@
         }
       }
     },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.0.tgz",
+      "integrity": "sha512-6ob45Oh9pXmfprKqUiEeMz/tjtVTFQTgDDz1xAMKMrIvyrYjAmRbQZjMJfsictlL4phgjLhdLu27IkHNnNjB7g==",
     "node_modules/@inquirer/rawlist": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.0.tgz",
@@ -831,6 +885,7 @@
         }
       }
     },
+    "node_modules/@inquirer/search": {
     "node_modules/@inquirer/search": {
       "version": "3.0.12",
       "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.12.tgz",
@@ -858,6 +913,10 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.0.tgz",
       "integrity": "sha512-KkXQ4aSySWimpV4V/TUJWdB3tdfENZUU765GjOIZ0uPwdbGIG6jrxD4dDf1w68uP+DVtfNhr1A92B+0mbTZ8FA==",
+    "node_modules/@inquirer/select": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.0.tgz",
+      "integrity": "sha512-KkXQ4aSySWimpV4V/TUJWdB3tdfENZUU765GjOIZ0uPwdbGIG6jrxD4dDf1w68uP+DVtfNhr1A92B+0mbTZ8FA==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.1.10",
@@ -879,6 +938,7 @@
       }
     },
     "node_modules/@inquirer/type": {
+    "node_modules/@inquirer/type": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.6.tgz",
       "integrity": "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==",
@@ -893,6 +953,40 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -912,6 +1006,115 @@
         "run-parallel": "^1.1.9"
       },
       "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@oclif/core": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.2.10.tgz",
+      "integrity": "sha512-fAqcXgqkUm4v5FYy7qWP4w1HaOlVSVJveah+yVTo5Nm5kTiXhmD5mQQ7+knGeBaStyrtQy6WardoC2xSic9rlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.3.2",
+        "ansis": "^3.17.0",
+        "clean-stack": "^3.0.1",
+        "cli-spinners": "^2.9.2",
+        "debug": "^4.4.0",
+        "ejs": "^3.1.10",
+        "get-package-type": "^0.1.0",
+        "globby": "^11.1.0",
+        "indent-string": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lilconfig": "^3.1.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.6.3",
+        "string-width": "^4.2.3",
+        "supports-color": "^8",
+        "widest-line": "^3.1.0",
+        "wordwrap": "^1.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@oclif/plugin-autocomplete": {
+      "version": "3.2.27",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.27.tgz",
+      "integrity": "sha512-Aywx0Vw36k0fQVBa2uLb8FKblGAP7ly1cQ5bdKqL4BmhJnUasy37tpyIDMUor93asOS+kKFQg+52pOxQgXHi1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@oclif/core": "^4",
+        "ansis": "^3.16.0",
+        "debug": "^4.4.0",
+        "ejs": "^3.1.10"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@oclif/plugin-help": {
+      "version": "6.2.27",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.27.tgz",
+      "integrity": "sha512-RWSWtCFVObRmCwgxVOye3lsYbPHTnB7G4He5LEAg2tf600Sil5yXEOL/ULx1TqL/XOQxKqRvmLn/rLQOMT85YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oclif/core": "^4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@oclif/plugin-not-found": {
+      "version": "3.2.49",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.49.tgz",
+      "integrity": "sha512-3V74/O5aFAqTTCJ7+X04M6vmt59Dk8HimB2uOlGgJrR7yLMW9JsVWKpDZZ6fl1hfd5kK9Jn4oaEt/1LuwfW1wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/prompts": "^7.4.1",
+        "@oclif/core": "^4",
+        "ansis": "^3.17.0",
+        "fast-levenshtein": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
         "node": ">= 8"
       }
     },
@@ -1012,6 +1215,9 @@
       "version": "1.96.1",
       "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.96.1.tgz",
       "integrity": "sha512-TVtKEPuoGWQiaHTJlbwxgelsclb0U8ALLyw0IeIOcFa83fafkJih+RwSVJx7iP6CF4edssFzMwYkhca0rrpk7A==",
+      "version": "1.96.1",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.96.1.tgz",
+      "integrity": "sha512-TVtKEPuoGWQiaHTJlbwxgelsclb0U8ALLyw0IeIOcFa83fafkJih+RwSVJx7iP6CF4edssFzMwYkhca0rrpk7A==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.0.33",
@@ -1102,34 +1308,6 @@
         "eslint": ">=7"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.0.tgz",
-      "integrity": "sha512-+Fbls/diZ0RDerhE8kyC6hjADCXA1K4yVNlH0EYfd2XjyH0UGgzaQ8MlT0pCXAThfxv3QUAczHaL+qSv1E4/Cg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.0.tgz",
-      "integrity": "sha512-PPA6aEEsTPRz+/4xxAmaoWDqh67N7wFbgFUJGMnanCFs0TV99M0M8QhhaSCks+n6EbQoFvLQgYOGXxlMGQe/6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.40.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.0.tgz",
@@ -1142,244 +1320,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.0.tgz",
-      "integrity": "sha512-CoLEGJ+2eheqD9KBSxmma6ld01czS52Iw0e2qMZNpPDlf7Z9mj8xmMemxEucinev4LgHalDPczMyxzbq+Q+EtA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.0.tgz",
-      "integrity": "sha512-r7yGiS4HN/kibvESzmrOB/PxKMhPTlz+FcGvoUIKYoTyGd5toHp48g1uZy1o1xQvybwwpqpe010JrcGG2s5nkg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.0.tgz",
-      "integrity": "sha512-mVDxzlf0oLzV3oZOr0SMJ0lSDd3xC4CmnWJ8Val8isp9jRGl5Dq//LLDSPFrasS7pSm6m5xAcKaw3sHXhBjoRw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.0.tgz",
-      "integrity": "sha512-y/qUMOpJxBMy8xCXD++jeu8t7kzjlOCkoxxajL58G62PJGBZVl/Gwpm7JK9+YvlB701rcQTzjUZ1JgUoPTnoQA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.0.tgz",
-      "integrity": "sha512-GoCsPibtVdJFPv/BOIvBKO/XmwZLwaNWdyD8TKlXuqp0veo2sHE+A/vpMQ5iSArRUz/uaoj4h5S6Pn0+PdhRjg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.0.tgz",
-      "integrity": "sha512-L5ZLphTjjAD9leJzSLI7rr8fNqJMlGDKlazW2tX4IUF9P7R5TMQPElpH82Q7eNIDQnQlAyiNVfRPfP2vM5Avvg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.0.tgz",
-      "integrity": "sha512-ATZvCRGCDtv1Y4gpDIXsS+wfFeFuLwVxyUBSLawjgXK2tRE6fnsQEkE4csQQYWlBlsFztRzCnBvWVfcae/1qxQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.0.tgz",
-      "integrity": "sha512-wG9e2XtIhd++QugU5MD9i7OnpaVb08ji3P1y/hNbxrQ3sYEelKJOq1UJ5dXczeo6Hj2rfDEL5GdtkMSVLa/AOg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.0.tgz",
-      "integrity": "sha512-vgXfWmj0f3jAUvC7TZSU/m/cOE558ILWDzS7jBhiCAFpY2WEBn5jqgbqvmzlMjtp8KlLcBlXVD2mkTSEQE6Ixw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.0.tgz",
-      "integrity": "sha512-uJkYTugqtPZBS3Z136arevt/FsKTF/J9dEMTX/cwR7lsAW4bShzI2R0pJVw+hcBTWF4dxVckYh72Hk3/hWNKvA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.0.tgz",
-      "integrity": "sha512-rKmSj6EXQRnhSkE22+WvrqOqRtk733x3p5sWpZilhmjnkHkpeCgWsFFo0dGnUGeA+OZjRl3+VYq+HyCOEuwcxQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.0.tgz",
-      "integrity": "sha512-SpnYlAfKPOoVsQqmTFJ0usx0z84bzGOS9anAC0AZ3rdSo3snecihbhFTlJZ8XMwzqAcodjFU4+/SM311dqE5Sw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.0.tgz",
-      "integrity": "sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.0.tgz",
-      "integrity": "sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.0.tgz",
-      "integrity": "sha512-UtZQQI5k/b8d7d3i9AZmA/t+Q4tk3hOC0tMOMSq2GlMYOfxbesxG4mJSeDp0EHs30N9bsfwUvs3zF4v/RzOeTQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.0.tgz",
-      "integrity": "sha512-+m03kvI2f5syIqHXCZLPVYplP8pQch9JHyXKZ3AGMKlg8dCyr2PKHjwRLiW53LTrN/Nc3EqHOKxUxzoSPdKddA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.0.tgz",
-      "integrity": "sha512-lpPE1cLfP5oPzVjKMx10pgBmKELQnFJXHgvtHCtuJWOv8MxqdEIMNtgHgBFf7Ea2/7EuVwa9fodWUfXAlXZLZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -1403,6 +1343,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/lunr": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@types/lunr/-/lunr-2.3.7.tgz",
+      "integrity": "sha512-Tb/kUm38e8gmjahQzdCKhbdsvQ9/ppzHFfsJ0dMs3ckqQsRj+P5IkSAwFTBrBxdyr3E/LoMUUrZngjDYAjiE3A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/luxon": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
@@ -1411,6 +1358,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
+      "version": "22.15.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.2.tgz",
+      "integrity": "sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==",
       "version": "22.15.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.2.tgz",
       "integrity": "sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==",
@@ -1435,23 +1385,14 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "17.0.85",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.85.tgz",
-      "integrity": "sha512-5oBDUsRDsrYq4DdyHaL99gE1AJCfuDhyxqF6/55fvvOIRkp1PpKuwJ+aMiGJR+GJt7YqMNclPROTHF20vY2cXA==",
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.3.tgz",
+      "integrity": "sha512-UavfHguIjnnuq9O67uXfgy/h3SRJbidAYvNjLceB+2RIKVRBzVsh0QO+Pw6BCSQqFS9xwzKfwstXx0m6AbAREA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "^0.16",
         "csstype": "^3.0.2"
       }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/semver": {
       "version": "7.7.0",
@@ -1822,9 +1763,14 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.2.tgz",
       "integrity": "sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.2.tgz",
+      "integrity": "sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@vitest/spy": "3.1.2",
+        "@vitest/utils": "3.1.2",
         "@vitest/spy": "3.1.2",
         "@vitest/utils": "3.1.2",
         "chai": "^5.2.0",
@@ -1838,9 +1784,13 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.2.tgz",
       "integrity": "sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.2.tgz",
+      "integrity": "sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@vitest/spy": "3.1.2",
         "@vitest/spy": "3.1.2",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
@@ -1865,6 +1815,9 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
       "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
+      "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1878,9 +1831,13 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.2.tgz",
       "integrity": "sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.2.tgz",
+      "integrity": "sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@vitest/utils": "3.1.2",
         "@vitest/utils": "3.1.2",
         "pathe": "^2.0.3"
       },
@@ -1892,9 +1849,13 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.2.tgz",
       "integrity": "sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.2.tgz",
+      "integrity": "sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@vitest/pretty-format": "3.1.2",
         "@vitest/pretty-format": "3.1.2",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
@@ -1904,6 +1865,9 @@
       }
     },
     "node_modules/@vitest/spy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.2.tgz",
+      "integrity": "sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==",
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.2.tgz",
       "integrity": "sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==",
@@ -1920,9 +1884,13 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
       "integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
+      "integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@vitest/pretty-format": "3.1.2",
         "@vitest/pretty-format": "3.1.2",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
@@ -2365,6 +2333,31 @@
         "@esbuild/win32-arm64": "0.25.3",
         "@esbuild/win32-ia32": "0.25.3",
         "@esbuild/win32-x64": "0.25.3"
+        "@esbuild/aix-ppc64": "0.25.3",
+        "@esbuild/android-arm": "0.25.3",
+        "@esbuild/android-arm64": "0.25.3",
+        "@esbuild/android-x64": "0.25.3",
+        "@esbuild/darwin-arm64": "0.25.3",
+        "@esbuild/darwin-x64": "0.25.3",
+        "@esbuild/freebsd-arm64": "0.25.3",
+        "@esbuild/freebsd-x64": "0.25.3",
+        "@esbuild/linux-arm": "0.25.3",
+        "@esbuild/linux-arm64": "0.25.3",
+        "@esbuild/linux-ia32": "0.25.3",
+        "@esbuild/linux-loong64": "0.25.3",
+        "@esbuild/linux-mips64el": "0.25.3",
+        "@esbuild/linux-ppc64": "0.25.3",
+        "@esbuild/linux-riscv64": "0.25.3",
+        "@esbuild/linux-s390x": "0.25.3",
+        "@esbuild/linux-x64": "0.25.3",
+        "@esbuild/netbsd-arm64": "0.25.3",
+        "@esbuild/netbsd-x64": "0.25.3",
+        "@esbuild/openbsd-arm64": "0.25.3",
+        "@esbuild/openbsd-x64": "0.25.3",
+        "@esbuild/sunos-x64": "0.25.3",
+        "@esbuild/win32-arm64": "0.25.3",
+        "@esbuild/win32-ia32": "0.25.3",
+        "@esbuild/win32-x64": "0.25.3"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2545,6 +2538,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -2629,6 +2635,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/external-editor": {
@@ -2878,6 +2896,9 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2953,6 +2974,43 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3054,6 +3112,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3144,6 +3211,9 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3206,6 +3276,15 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3262,6 +3341,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "license": "MIT"
+    },
     "node_modules/luxon": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
@@ -3304,15 +3389,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "@isaacs/brace-expansion": "^5.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3735,6 +3820,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
@@ -3808,6 +3906,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3846,6 +3950,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3905,6 +4018,7 @@
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.4.4",
+        "fdir": "^6.4.4",
         "picomatch": "^4.0.2"
       },
       "engines": {
@@ -3915,6 +4029,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
       "version": "6.4.4",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
       "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
@@ -4058,9 +4175,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4068,7 +4185,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {
@@ -4101,14 +4218,19 @@
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
+        "fdir": "^6.4.4",
         "picomatch": "^4.0.2",
         "postcss": "^8.5.3",
         "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
         "tinyglobby": "^0.2.13"
       },
       "bin": {
@@ -4176,6 +4298,9 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.2.tgz",
       "integrity": "sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.2.tgz",
+      "integrity": "sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4196,6 +4321,9 @@
       }
     },
     "node_modules/vite/node_modules/fdir": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
       "version": "6.4.4",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
       "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
@@ -4227,6 +4355,9 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.2.tgz",
       "integrity": "sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.2.tgz",
+      "integrity": "sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4237,18 +4368,29 @@
         "@vitest/snapshot": "3.1.2",
         "@vitest/spy": "3.1.2",
         "@vitest/utils": "3.1.2",
+        "@vitest/expect": "3.1.2",
+        "@vitest/mocker": "3.1.2",
+        "@vitest/pretty-format": "^3.1.2",
+        "@vitest/runner": "3.1.2",
+        "@vitest/snapshot": "3.1.2",
+        "@vitest/spy": "3.1.2",
+        "@vitest/utils": "3.1.2",
         "chai": "^5.2.0",
         "debug": "^4.4.0",
+        "expect-type": "^1.2.1",
         "expect-type": "^1.2.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
         "std-env": "^3.9.0",
+        "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.13",
         "tinyglobby": "^0.2.13",
         "tinypool": "^1.0.2",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0",
+        "vite-node": "3.1.2",
         "vite-node": "3.1.2",
         "why-is-node-running": "^2.3.0"
       },
@@ -4265,6 +4407,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.1.2",
+        "@vitest/ui": "3.1.2",
         "@vitest/browser": "3.1.2",
         "@vitest/ui": "3.1.2",
         "happy-dom": "*",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "theherk"
   ],
   "license": "MIT",
+  "type": "module",
   "preferences": [
     {
       "name": "vaultPath",
@@ -40,12 +41,20 @@
       "description": "Override the vault config filename (default: .obsidian)"
     },
     {
-      "name": "excludedFolders",
+      "name": "includedPatterns",
       "type": "textfield",
-      "placeholder": "folder1, folder2, ...",
-      "title": "Exclude following folders",
+      "title": "Include following files",
+      "placeholder": "**/folder/**, *.pdf, ...",
       "required": false,
-      "description": "Specify which folders to exclude (comma separated)"
+      "description": "Files to include (vault-relative). Vault root is default."
+    },
+    {
+      "name": "excludedPatterns",
+      "type": "textfield",
+      "placeholder": "**/folder/**, *.pdf, ...",
+      "title": "Exclude following files",
+      "required": false,
+      "description": "Files to exclude (vault-relative1). Exclusions take precedence."
     },
     {
       "name": "removeYAML",
@@ -80,13 +89,7 @@
       "arguments": [
         {
           "name": "searchArgument",
-          "placeholder": "Note",
-          "type": "text",
-          "required": false
-        },
-        {
-          "name": "tagArgument",
-          "placeholder": "Tag",
+          "placeholder": "Search Query",
           "type": "text",
           "required": false
         }
@@ -125,22 +128,79 @@
           "default": false
         },
         {
-          "name": "searchContent",
-          "type": "checkbox",
-          "label": "Search Content",
-          "title": "Search Content",
+          "name": "initialSearchText",
+          "type": "textfield",
+          "title": "Pre-fill Search Query",
           "required": false,
-          "description": "Use the content of notes for searching",
-          "default": false
+          "description": "Pre-fill the search bar with a default query"
         },
         {
-          "name": "fuzzySearch",
-          "type": "checkbox",
-          "label": "Use Fuzzy Search",
-          "title": "Use Fuzzy Search",
+          "name": "prefSearchScope",
+          "type": "dropdown",
+          "label": "Select Default Search Scope",
+          "title": "Select Default Search Scope",
           "required": false,
-          "description": "If fuzzy search should be used",
-          "default": false
+          "description": "Used when the query has no field (e.g., vacation plan)",
+          "default": "title",
+          "data": [
+            {
+              "title": "file:",
+              "value": "title"
+            },
+            {
+              "title": "anyname: (Title & aliases)",
+              "value": "anyname"
+            },
+            {
+              "title": "full: (Content & path)",
+              "value": "full"
+            }
+          ]
+        },
+        {
+          "name": "userDefinedSearchScope",
+          "type": "textfield",
+          "label": "Define Default Search Scope",
+          "title": "Define Default Search Scope",
+          "required": false,
+          "description": "Enter note property to override selected search scope",
+          "default": "",
+          "placeholder": "e.g., path, tags, locations, bookmarked..."
+        },
+        {
+          "name": "prefSortOrder",
+          "type": "dropdown",
+          "label": "Select Default Sort Order",
+          "title": "Select Default Sort Order",
+          "required": false,
+          "description": "Selct a default sort order for the search results",
+          "default": "az",
+          "data": [
+            {
+              "title": "A to Z",
+              "value": "az"
+            },
+            {
+              "title": "Z to A",
+              "value": "za"
+            },
+            {
+              "title": "Modified: newest first",
+              "value": "mn"
+            },
+            {
+              "title": "Modified: oldest first",
+              "value": "mo"
+            },
+            {
+              "title": "Created: newest first",
+              "value": "cn"
+            },
+            {
+              "title": "Created: oldest first",
+              "value": "co"
+            }
+          ]
         },
         {
           "name": "primaryAction",
@@ -171,26 +231,29 @@
       ]
     },
     {
-      "name": "starredNotesCommand",
-      "title": "Bookmarked Notes",
+      "name": "importantNotesCommand",
+      "title": "Important Notes",
       "subtitle": "Obsidian",
-      "description": "Search, open, view, copy, paste and edit bookmarked notes in Obsidian.",
+      "description": "Search, open, view, copy, paste and edit important notes in Obsidian. By default all bookmarked",
       "mode": "view",
       "arguments": [
         {
           "name": "searchArgument",
-          "placeholder": "Note",
-          "type": "text",
-          "required": false
-        },
-        {
-          "name": "tagArgument",
-          "placeholder": "Tag",
+          "placeholder": "Search Query",
           "type": "text",
           "required": false
         }
       ],
       "preferences": [
+        {
+          "name": "prefilterSearchQuery",
+          "type": "textfield",
+          "title": "Pre-filter Search Query",
+          "required": false,
+          "description": "Pre-fill the search bar with a default query",
+          "placeholder": "Type search query...",
+          "default": "bookmarked:"
+        },
         {
           "name": "appendTemplate",
           "type": "textfield",
@@ -221,15 +284,6 @@
           "title": "Show Metadata",
           "required": false,
           "description": "Show the notes metadata in a detail view (only works when Show Detail is enabled)",
-          "default": false
-        },
-        {
-          "name": "searchContent",
-          "type": "checkbox",
-          "label": "Search Content",
-          "title": "Search Content",
-          "required": false,
-          "description": "Use the content of notes for searching",
           "default": false
         },
         {
@@ -399,6 +453,23 @@
           "default": ""
         },
         {
+          "name": "defaultTags",
+          "type": "textfield",
+          "placeholder": "tag1, tag2, ...",
+          "title": "Default Tags",
+          "required": false,
+          "description": "The default selected tags"
+        },
+        {
+          "name": "defaultKeys",
+          "type": "textfield",
+          "label": "Default YAML Keys",
+          "title": "Default YAML Keys",
+          "required": false,
+          "description": "Adds YAML keys automatically",
+          "placeholder": "e.g, {key1,a b c} {key2,{x,y,z}} {key3,uvw}"
+        },
+        {
           "name": "fillFormWithDefaults",
           "type": "checkbox",
           "label": "Fill form with defaults",
@@ -408,24 +479,6 @@
           "description": "Fill form with default values"
         },
         {
-          "name": "prefTag",
-          "type": "textfield",
-          "placeholder": "untagged",
-          "title": "Default Tag",
-          "required": false,
-          "description": "The default selected tag",
-          "default": ""
-        },
-        {
-          "name": "tags",
-          "type": "textfield",
-          "placeholder": "tag1, tag2, tag3, ...",
-          "title": "Tags",
-          "required": false,
-          "description": "The tags which will be suggested on note creation",
-          "default": ""
-        },
-        {
           "name": "folderActions",
           "type": "textfield",
           "placeholder": "folder1, folder2, folder3, ...",
@@ -433,6 +486,35 @@
           "required": false,
           "description": "Add actions to folders (comma separated)",
           "default": ""
+        },
+        {
+          "name": "prefEnableJDex",
+          "type": "checkbox",
+          "label": "Yes",
+          "title": "Show Johnny.Decimal fields",
+          "required": false,
+          "description": "Show JDex-specific fields in Create Note",
+          "default": false
+        },
+        {
+          "name": "jdexTitleSeparator",
+          "type": "textfield",
+          "label": "JDex Title Separator",
+          "title": "JDex Title Separator",
+          "required": false,
+          "description": "AC.ID + Title = 'AC.ID<sep>Title'",
+          "default": " ",
+          "placeholder": "<sep>"
+        },
+        {
+          "name": "jdexRootTag",
+          "type": "textfield",
+          "label": "JDex Root Tag",
+          "title": "JDex Root Tag",
+          "required": false,
+          "description": "Adds existing tags like '<root>/A0-A9_<area>/AC_<category>'",
+          "default": "JDex",
+          "placeholder": "<root>"
         }
       ]
     },
@@ -509,10 +591,10 @@
         {
           "name": "excludedFolders",
           "type": "textfield",
-          "placeholder": "folder1, folder2, ...",
+          "placeholder": "folder1/folder2, folder3, ...",
           "title": "Exclude following folders",
           "required": false,
-          "description": "Specify which folders to exclude (comma separated)"
+          "description": "Folders to exclude (vault-relative)"
         },
         {
           "name": "imageSize",
@@ -620,21 +702,22 @@
     "@raycast/api": "^1.94.0",
     "@types/uuid": "^8.3.4",
     "fuse.js": "^7.0.0",
+    "gray-matter": "^4.0.3",
+    "lunr": "^2.3.9",
     "luxon": "^3.4.4",
-    "minisearch": "^7.1.2",
-    "pako": "^2.1.0",
+    "minimatch": "^10.0.3",
     "uuid": "^8.3.2",
     "yaml": "^2.1.1"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^1.0.6",
+    "@types/lunr": "^2.3.7",
     "@types/luxon": "^3.4.2",
     "@types/node": "^22.14.1",
-    "@types/pako": "^2.0.3",
-    "@types/react": "^17.0.52",
+    "@types/react": "^19.0.3",
     "eslint": "^8.42.0",
     "prettier": "^2.8.8",
-    "typescript": "^4.5.4",
+    "typescript": "^5.6.3",
     "vitest": "^3.1.1"
   },
   "scripts": {
@@ -643,6 +726,8 @@
     "fix-lint": "ray lint --fix",
     "lint": "ray lint",
     "publish": "ray publish",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ui": "vitest --ui"
   }
 }

--- a/package.json
+++ b/package.json
@@ -706,6 +706,8 @@
     "lunr": "^2.3.9",
     "luxon": "^3.4.4",
     "minimatch": "^10.0.3",
+    "minisearch": "^7.2.0",
+    "pako": "^2.1.0",
     "uuid": "^8.3.2",
     "yaml": "^2.1.1"
   },
@@ -714,6 +716,7 @@
     "@types/lunr": "^2.3.7",
     "@types/luxon": "^3.4.2",
     "@types/node": "^22.14.1",
+    "@types/pako": "^2.0.4",
     "@types/react": "^19.0.3",
     "eslint": "^8.42.0",
     "prettier": "^2.8.8",

--- a/raycast-env.d.ts
+++ b/raycast-env.d.ts
@@ -12,8 +12,10 @@ type ExtensionPreferences = {
   "vaultPath"?: string,
   /** Config filename - Override the vault config filename (default: .obsidian) */
   "configFileName": string,
-  /** Exclude following folders - Specify which folders to exclude (comma separated) */
-  "excludedFolders"?: string,
+  /** Include following files - Files to include (vault-relative). Vault root is default. */
+  "includedPatterns"?: string,
+  /** Exclude following files - Files to exclude (vault-relative1). Exclusions take precedence. */
+  "excludedPatterns"?: string,
   /** Remove content - Hide YAML frontmatter for copying and viewing notes */
   "removeYAML"?: boolean,
   /** undefined - Hide LaTeX (surrounded by $$ or $) for copying and viewing notes */
@@ -36,15 +38,21 @@ declare namespace Preferences {
   "showDetail": boolean,
   /** Show Metadata - Show the notes metadata in a detail view (only works when Show Detail is enabled) */
   "showMetadata": boolean,
-  /** Search Content - Use the content of notes for searching */
-  "searchContent": boolean,
-  /** Use Fuzzy Search - If fuzzy search should be used */
-  "fuzzySearch": boolean,
+  /** Pre-fill Search Query - Pre-fill the search bar with a default query */
+  "initialSearchText"?: string,
+  /** Select Default Search Scope - Used when the query has no field (e.g., vacation plan) */
+  "prefSearchScope": "title" | "anyname" | "full",
+  /** Define Default Search Scope - Enter note property to override selected search scope */
+  "userDefinedSearchScope": string,
+  /** Select Default Sort Order - Selct a default sort order for the search results */
+  "prefSortOrder": "az" | "za" | "mn" | "mo" | "cn" | "co",
   /** Primary Action - Select a primary action to be executed on enter */
   "primaryAction"?: "quicklook" | "obsidian" | "newpane" | "defaultapp"
 }
-  /** Preferences accessible in the `starredNotesCommand` command */
-  export type StarredNotesCommand = ExtensionPreferences & {
+  /** Preferences accessible in the `importantNotesCommand` command */
+  export type ImportantNotesCommand = ExtensionPreferences & {
+  /** Pre-filter Search Query - Pre-fill the search bar with a default query */
+  "prefilterSearchQuery": string,
   /** Template for Append action - Specify a template for Append action (e.g. '- {content}') */
   "appendTemplate"?: string,
   /** Template for Append Selected Text action - Specify a template for Append Selected Text action (e.g. '- {content}') */
@@ -53,8 +61,6 @@ declare namespace Preferences {
   "showDetail": boolean,
   /** Show Metadata - Show the notes metadata in a detail view (only works when Show Detail is enabled) */
   "showMetadata": boolean,
-  /** Search Content - Use the content of notes for searching */
-  "searchContent": boolean,
   /** Primary Action - Select a primary action to be executed on enter */
   "primaryAction"?: "quicklook" | "obsidian" | "newpane" | "defaultapp"
 }
@@ -92,14 +98,20 @@ declare namespace Preferences {
   "prefNoteName": string,
   /** Default Note Content - The default note content (supports templates) */
   "prefNoteContent": string,
+  /** Default Tags - The default selected tags */
+  "defaultTags"?: string,
+  /** Default YAML Keys - Adds YAML keys automatically */
+  "defaultKeys"?: string,
   /** Fill form with defaults - Fill form with default values */
   "fillFormWithDefaults": boolean,
-  /** Default Tag - The default selected tag */
-  "prefTag": string,
-  /** Tags - The tags which will be suggested on note creation */
-  "tags": string,
   /** Folder Actions - Add actions to folders (comma separated) */
-  "folderActions": string
+  "folderActions": string,
+  /** Show Johnny.Decimal fields - Show JDex-specific fields in Create Note */
+  "prefEnableJDex": boolean,
+  /** JDex Title Separator - AC.ID + Title = 'AC.ID<sep>Title' */
+  "jdexTitleSeparator": string,
+  /** JDex Root Tag - Adds existing tags like '<root>/A0-A9_<area>/AC_<category>' */
+  "jdexRootTag": string
 }
   /** Preferences accessible in the `randomNoteCommand` command */
   export type RandomNoteCommand = ExtensionPreferences & {
@@ -112,7 +124,7 @@ declare namespace Preferences {
 }
   /** Preferences accessible in the `searchMedia` command */
   export type SearchMedia = ExtensionPreferences & {
-  /** Exclude following folders - Specify which folders to exclude (comma separated) */
+  /** Exclude following folders - Folders to exclude (vault-relative) */
   "excludedFolders"?: string,
   /** Image Size - Select the image size to display */
   "imageSize"?: "small" | "medium" | "large"
@@ -139,17 +151,13 @@ declare namespace Preferences {
 declare namespace Arguments {
   /** Arguments passed to the `searchNoteCommand` command */
   export type SearchNoteCommand = {
-  /** Note */
-  "searchArgument": string,
-  /** Tag */
-  "tagArgument": string
+  /** Search Query */
+  "searchArgument": string
 }
-  /** Arguments passed to the `starredNotesCommand` command */
-  export type StarredNotesCommand = {
-  /** Note */
-  "searchArgument": string,
-  /** Tag */
-  "tagArgument": string
+  /** Arguments passed to the `importantNotesCommand` command */
+  export type ImportantNotesCommand = {
+  /** Search Query */
+  "searchArgument": string
 }
   /** Arguments passed to the `openVaultCommand` command */
   export type OpenVaultCommand = {}

--- a/src/api/logger/debugger.ts
+++ b/src/api/logger/debugger.ts
@@ -1,0 +1,82 @@
+import { Logger } from "./logger.service";
+
+/**
+ * Central switches for debug scopes.
+ * Flip these on/off or expose setters to toggle at runtime.
+ */
+// Example:
+//   const dbgParse = createDebugger("parse");
+//   dbgParse("tokens parsed", toks);
+export const DEBUG_FLAGS = {
+  lexer: false,
+  parse: false,
+  eval: false,
+  search: false,
+  yaml: false,
+  custom: false,
+  loadNotes: false,
+  excludeNotes: false,
+  createNoteForm: false,
+  notesService: false,
+};
+export const targetNoteDebugActive = false; // for debugging a specific note during search
+
+/**
+ * Create a scoped debugger that is gated by a flag.
+ *
+ * Usage:
+ *   const dbgParse = createDebugger("parse");
+ *   dbgParse("tokens parsed", toks);
+ *
+ * The logger will format the line with the scope included internally.
+ */
+export function createDebugger<
+  K extends keyof typeof DEBUG_FLAGS
+>(flag: K) {
+  const logger = new Logger(flag as string);
+  return (...args: unknown[]) => {
+    if (!DEBUG_FLAGS[flag]) return;
+
+    // Join all arguments into a single string since Logger.debug takes one arg
+    const message = args
+      .map((a) => (typeof a === "string" ? a : j(a, 0)))
+      .join(" ");
+
+    logger.debug(message);
+  };
+}
+
+/**
+ * Change flags at runtime if needed.
+ * Example: setDebugFlag("parse", false)
+ */
+export function setDebugFlag<K extends keyof typeof DEBUG_FLAGS>(
+  flag: K,
+  enabled: boolean,
+) {
+  DEBUG_FLAGS[flag] = enabled;
+}
+
+/**
+ * Helper to pretty-print JSON safely.
+ */
+export function j(obj: unknown, space: number = 2) {
+  try {
+    return JSON.stringify(obj, null, space);
+  } catch {
+    return String(obj);
+  }
+}
+
+/**
+ * Convenience: create common scoped debuggers.
+ */
+export const dbgLexer = createDebugger("lexer");
+export const dbgParse = createDebugger("parse");
+export const dbgEval = createDebugger("eval");
+export const dbgSearch = createDebugger("search");
+export const dbgYaml = createDebugger("yaml");
+export const dbgLoadNotes = createDebugger("loadNotes");
+export const dbgExcludeNotes = createDebugger("excludeNotes");
+export const dbgCNF = createDebugger("createNoteForm");
+export const dbgNS = createDebugger("notesService");

--- a/src/api/logger/targetNoteDebugger.ts
+++ b/src/api/logger/targetNoteDebugger.ts
@@ -1,0 +1,51 @@
+import { Doc, EvaluateOptions } from '../../utils/search/evaluator';
+import { TermNode } from '../../utils/search/parser';
+import { getFieldValues } from '../../utils/search/evaluator'; // if you want to reuse it
+import { dbgEval, targetNoteDebugActive } from './debugger';
+
+export function dumpTargetNoteDebug(
+    targetNoteTitle: string,
+    docs: Doc[],
+    fields: string[],
+    node: TermNode,
+    opts: EvaluateOptions,
+    matched: boolean
+) {
+    const isActive = targetNoteDebugActive;
+    if (!isActive) return;
+
+    const TARGET = targetNoteTitle;
+    for (const d of docs) {
+        if (String((d as any).id || "").includes(TARGET)) {
+            const docAny = d as any;
+            const ownKeys = Object.keys(docAny).sort();
+
+            const valuesByQueryField = Object.fromEntries(
+                fields.map((f) => [f, getFieldValues(d, f, opts)])
+            );
+
+            const valuesByDefaultField = Object.fromEntries(
+                (opts.defaultFields || []).map((f) => [f, getFieldValues(d, f, opts)])
+            );
+
+            const fieldMapKeys = Object.keys(opts.fieldMap || {});
+            const valuesByFieldMap = Object.fromEntries(
+                fieldMapKeys.map((f) => [f, getFieldValues(d, f, opts)])
+            );
+
+            const testDocJson = JSON.stringify(d, null, 2);
+
+            dbgEval('evalExactLeaf, TARGET DUMP', {
+                targetId: d.id,
+                query: { fields, raw: node.value, phrase: node.phrase, fuzzy: node.fuzzy, regex: node.regex?.pattern },
+                matched,
+                ownKeys,
+                docSnapshot: d,
+                valuesByQueryField,
+                valuesByDefaultField,
+                valuesByFieldMap,
+                testDocSnippet: `const DOC: Doc = ${testDocJson} as const;`,
+            });
+        }
+    }
+}

--- a/src/api/vault/__tests__/vault.service.spec.ts
+++ b/src/api/vault/__tests__/vault.service.spec.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+// --- Mocks -----------------------------------------------------------------
+
+// Mock Raycast API preferences + icons
+vi.mock("@raycast/api", () => {
+  // Default prefs; tests will override with __setPreferences(...)
+  let prefs: any = {
+    // SearchNotePreferences
+    excludedPatterns: "",
+    // we store included patterns here (comma-separated)
+    includedPatterns: "",
+    // GlobalPreferences
+    configFileName: ".obsidian",
+    vaultPath: "", // not used by these tests
+    removeYAML: false,
+    removeLatex: false,
+    removeLinks: false,
+  };
+
+  return {
+    getPreferenceValues: vi.fn(() => prefs),
+    // test helper to set/override preferences
+    __setPreferences: (next: Record<string, any>) => {
+      prefs = { ...prefs, ...next };
+    },
+    Icon: { Video: "video", Microphone: "microphone" },
+  };
+});
+
+// Mock bookmarks (no note is bookmarked)
+vi.mock("./notes/bookmarks/bookmarks.service", () => ({
+  getBookmarkedNotePaths: vi.fn(() => [] as string[]),
+}));
+
+// --- Imports under test (after mocks) --------------------------------------
+import { loadNotes } from "../vault.service";
+import type { Vault } from "../vault.types";
+// Pull in the test-only setter
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { __setPreferences } from "@raycast/api";
+
+// --- Helpers ---------------------------------------------------------------
+
+function makeTmpVault(): { dir: string; vault: Vault; cleanup: () => void } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vault-"));
+  const vault: Vault = { name: "tmp", key: dir, path: dir };
+  const cleanup = () => {
+    // best-effort recursive delete
+    fs.rmSync(dir, { recursive: true, force: true });
+  };
+  return { dir, vault, cleanup };
+}
+
+function writeFile(p: string, content = "content") {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content, "utf8");
+}
+
+function touchMd(dir: string, rel: string, content = "# title\n") {
+  writeFile(path.join(dir, rel), content);
+}
+
+// Ensure stable defaults before each test
+beforeEach(() => {
+  __setPreferences({
+    excludedPatterns: "",
+    includedPatterns: "",
+    configFileName: ".obsidian",
+    removeYAML: false,
+    removeLatex: false,
+    removeLinks: false,
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// --- Tests -----------------------------------------------------------------
+
+describe("vault.service - include/exclude during loadNotes()", () => {
+  it("excludes files matching a glob pattern anywhere (e.g., **/*_--Demo*)", () => {
+    const { dir, vault, cleanup } = makeTmpVault();
+    try {
+      // Arrange: create files
+      touchMd(dir, "Keep.md");
+      touchMd(dir, "Note_--Demo.md");
+      touchMd(dir, "nested/Sub_--Demo.md");
+      touchMd(dir, "nested/Deep/KeepToo.md");
+
+      // Exclude any file with `_--Demo` in its name
+      __setPreferences({
+        excludedPatterns: "**/*_--Demo*",
+        includedPatterns: "", // no include restriction
+      });
+
+      // Act
+      const notes = loadNotes(vault);
+      const paths = notes.map((n) => path.relative(dir, n.path)).sort();
+
+      // Assert: demo files are missing; the others are present
+      expect(paths).toEqual(["Keep.md", path.join("nested", "Deep", "KeepToo.md")].sort());
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("includes only files matching include globs (e.g., notes/**) when include is set", () => {
+    const { dir, vault, cleanup } = makeTmpVault();
+    try {
+      // Arrange
+      touchMd(dir, "notes/A.md");
+      touchMd(dir, "notes/sub/B.md");
+      touchMd(dir, "outside/C.md");
+
+      // Only include the notes/** subtree
+      __setPreferences({
+        includedPatterns: "notes/**",
+        excludedPatterns: "",
+      });
+
+      // Act
+      const notes = loadNotes(vault);
+      const rel = notes.map((n) => path.relative(dir, n.path)).sort();
+
+      // Assert: only the notes/** files are present
+      expect(rel).toEqual(["notes/A.md", "notes/sub/B.md"].sort());
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("supports combined include + exclude where exclude wins", () => {
+    const { dir, vault, cleanup } = makeTmpVault();
+    try {
+      // Arrange
+      touchMd(dir, "notes/Keep.md");
+      touchMd(dir, "notes/Note_--Demo.md");
+      touchMd(dir, "notes/sub/AlsoKeep.md");
+
+      __setPreferences({
+        includedPatterns: "notes/**",
+        excludedPatterns: "**/*_--Demo*",
+      });
+
+      // Act
+      const notes = loadNotes(vault);
+      const rel = notes.map((n) => path.relative(dir, n.path)).sort();
+
+      // Assert: exclude removes the _--Demo file even though it’s under an included dir
+      expect(rel).toEqual(["notes/Keep.md", "notes/sub/AlsoKeep.md"].sort());
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("traverses ancestors due to partial matching and still finds deep matches from include patterns", () => {
+    const { dir, vault, cleanup } = makeTmpVault();
+    try {
+      // Arrange
+      touchMd(dir, "projects/app/README.md");
+      touchMd(dir, "projects/app/docs/guide.md");
+      touchMd(dir, "other/README.md");
+
+      // Include only READMEs nested somewhere under projects/**
+      __setPreferences({
+        includedPatterns: "projects/**/README.md",
+        excludedPatterns: "",
+      });
+
+      // Act
+      const notes = loadNotes(vault);
+      const rel = notes.map((n) => path.relative(dir, n.path)).sort();
+
+      // Assert: only projects/**/README.md is included
+      expect(rel).toEqual(["projects/app/README.md"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("respects DEFAULT_EXCLUDED_PATHS like .obsidian and ignores files inside", () => {
+    const { dir, vault, cleanup } = makeTmpVault();
+    try {
+      // Arrange
+      // file in default-excluded dir
+      touchMd(dir, ".obsidian/should-not-load.md");
+      // a normal file
+      touchMd(dir, "Root.md");
+
+      __setPreferences({
+        includedPatterns: "",
+        excludedPatterns: "", // rely on DEFAULT_EXCLUDED_PATHS
+        configFileName: ".obsidian",
+      });
+
+      // Act
+      const notes = loadNotes(vault);
+      const rel = notes.map((n) => path.relative(dir, n.path));
+
+      // Assert
+      expect(rel).toContain("Root.md");
+      expect(rel).not.toContain(path.join(".obsidian", "should-not-load.md"));
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/api/vault/notes/notes.types.ts
+++ b/src/api/vault/notes/notes.types.ts
@@ -1,9 +1,15 @@
 export interface Note {
   title: string;
   path: string;
-  lastModified: Date;
+  created: Date;
+  modified: Date;
+  tags: string[];
+  content: string;
   bookmarked: boolean;
-}
+  aliases: string[];
+  locations: string[];
+  [key:string]: any; // Additional properties from YAML frontmatter
+};
 
 export interface NoteWithContent extends Note {
   content: string;
@@ -12,9 +18,15 @@ export interface NoteWithContent extends Note {
 export interface CreateNoteParams {
   path: string;
   name: string;
+  jdex: string;
+  fullName: string;
   content: string;
   tags: string[];
-}
+  locations: string[];
+  availableTags: string[];
+  allNotes: Note[];
+  yamlKeys: string;
+};
 
 export interface CodeBlock {
   language: string;

--- a/src/components/CreateNoteForm.tsx
+++ b/src/components/CreateNoteForm.tsx
@@ -1,31 +1,72 @@
-import { ActionPanel, Form, Action, getPreferenceValues, Keyboard, popToRoot, closeMainWindow } from "@raycast/api";
+import { ActionPanel, Form, Action, getPreferenceValues, Keyboard, popToRoot, closeMainWindow, Clipboard, showHUD } from "@raycast/api";
 import { renewCache } from "../api/cache/cache.service";
 import { parseFolderActionsPreferences, parseTagsPreferences } from "../api/preferences/preferences.service";
 import { createNote } from "../api/vault/notes/notes.service";
 import { CreateNoteParams } from "../api/vault/notes/notes.types";
 import { Vault } from "../api/vault/vault.types";
 import { NoteFormPreferences } from "../utils/preferences";
+import { useMemo } from "react";
+import { getAllFolderPaths } from "../utils/folderPaths";
+import { useNotes } from "../utils/hooks";
+import { useState } from "react";
+import { tagsForNotes } from "../utils/yaml";
+import { dbgCNF } from "../api/logger/debugger";
 
 export function CreateNoteForm(props: { vault: Vault; showTitle: boolean }) {
   const { vault, showTitle } = props;
 
-  const pref = getPreferenceValues<NoteFormPreferences>();
-  const { prefTag, prefPath } = pref;
+  const pref = getPreferenceValues<NoteFormPreferences>();  const { folderActions, prefPath, prefEnableJDex, defaultKeys, defaultTags } = pref;
+  const showJDex = !!prefEnableJDex;
 
-  const folderActions = parseFolderActionsPreferences(pref.folderActions);
-  const tags = parseTagsPreferences(pref.tags);
-  if (prefTag) {
-    tags.push(prefTag);
-  }
+  const defaultTagsArray = useMemo(() => {
+    if (!(pref.fillFormWithDefaults && defaultTags)) return [];
+    return defaultTags.split(",").map((tag) => tag.trim()).filter(Boolean);
+  }, [defaultTags, pref.fillFormWithDefaults]);
 
-  async function createNewNote(params: CreateNoteParams, path?: string) {
-    if (path) {
+  const folderActionTargets = useMemo(
+    () => parseFolderActionsPreferences(folderActions || ""),
+    [folderActions]
+  );
+
+  const [copyToClipboard, setCopyToClipboard] = useState(false);
+  const { notes: allNotes } = useNotes(vault);
+
+  const availableTags = useMemo(() => {
+    if (!allNotes) return defaultTagsArray;
+    return Array.from(new Set([...tagsForNotes(allNotes), ...defaultTagsArray]));
+  }, [allNotes, defaultTagsArray]);
+
+  const availableLocations = useMemo(() => {
+    if (!allNotes) return [];
+    return Array.from(new Set(allNotes.flatMap((note) => note.locations ?? [])));
+  }, [allNotes]);
+
+  const availableFolderPaths = useMemo(() => getAllFolderPaths(vault), [vault]);
+
+  dbgCNF("Available tags:", availableTags);
+
+  async function createNewNote(params: CreateNoteParams, path: string | undefined = undefined) {
+    if (path !== undefined) {
       params.path = path;
     }
+
+    params.availableTags = availableTags;
+    params.allNotes = allNotes ?? [];
+
     const saved = await createNote(vault, params);
     if (saved) {
       renewCache(vault);
     }
+
+    if (!saved) {
+      dbgCNF("Note creation was cancelled.");
+    } else {
+      if (copyToClipboard && params.fullName) {
+        await Clipboard.copy(params.fullName);
+        await showHUD(`Title "${params.fullName}" copied to clipboard`);
+      }
+    }
+
     popToRoot();
     closeMainWindow();
   }
@@ -35,8 +76,8 @@ export function CreateNoteForm(props: { vault: Vault; showTitle: boolean }) {
       navigationTitle={showTitle ? "Create Note for " + vault.name : ""}
       actions={
         <ActionPanel>
-          <Action.SubmitForm title="Create" onSubmit={createNewNote} />
-          {folderActions.map((folder, index) => (
+          <Action.SubmitForm title="Create" onSubmit={(props: CreateNoteParams) => createNewNote(props)} />
+          {Array.isArray(folderActionTargets) && folderActionTargets.map((folder: string, index: number) => (
             <Action.SubmitForm
               title={"Create in " + folder}
               onSubmit={(props: CreateNoteParams) => createNewNote(props, folder)}
@@ -47,23 +88,59 @@ export function CreateNoteForm(props: { vault: Vault; showTitle: boolean }) {
         </ActionPanel>
       }
     >
+      {showJDex && (
+        <Form.TextField
+          title="JDex"
+          id="jdex"
+          placeholder="AC.ID"
+        />
+      )}
       <Form.TextField
         title="Name"
         id="name"
         placeholder="Name of note"
         defaultValue={pref.fillFormWithDefaults ? pref.prefNoteName : ""}
       />
+      {showJDex && (
+        <Form.Checkbox
+          label="Copy title to clipboard"
+          id="copytitle"
+          defaultValue={false}
+          onChange={setCopyToClipboard}
+        />
+      )}
+      {availableFolderPaths.length > 0 && (
+        <Form.Dropdown
+          title="Path"
+          id="path"
+          defaultValue={prefPath && availableFolderPaths.includes(prefPath) ? prefPath : availableFolderPaths[0]}
+          placeholder="Choose a folder"
+        >
+          {availableFolderPaths.map((fp) => (
+            <Form.Dropdown.Item key={fp} value={fp} title={fp} />
+          ))}
+        </Form.Dropdown>
+      )}
+      {availableTags.length > 0 && (
+        <Form.TagPicker id="tags" title="Tags" defaultValue={defaultTagsArray}>
+          {availableTags.map((tag) => (
+            <Form.TagPicker.Item value={tag} title={tag} key={tag} />
+          ))}
+        </Form.TagPicker>
+      )}
+      {showJDex && availableLocations.length > 0 && (
+        <Form.TagPicker id="locations" title="Locations">
+          {availableLocations.map((location) => (
+            <Form.TagPicker.Item value={location} title={location} key={location} />
+          ))}
+        </Form.TagPicker>
+      )}
       <Form.TextField
-        title="Path"
-        id="path"
-        defaultValue={prefPath ? prefPath : ""}
-        placeholder="path/to/note (optional)"
+        title="YAML Keys"
+        id="yamlKeys"
+        defaultValue={pref.fillFormWithDefaults && defaultKeys ? defaultKeys : ""}
+        placeholder="e.g, {key1,a b c} {key2,{x,y,z}} {key3,uvw}"
       />
-      <Form.TagPicker id="tags" title="Tags" defaultValue={prefTag ? [prefTag] : []}>
-        {tags.map((tag, index) => (
-          <Form.TagPicker.Item value={tag} title={tag} key={index} />
-        ))}
-      </Form.TagPicker>
       <Form.TextArea
         title="Content:"
         id="content"

--- a/src/components/NoteList/CreateNoteView.tsx
+++ b/src/components/NoteList/CreateNoteView.tsx
@@ -23,6 +23,7 @@ export function CreateNoteView(props: CreateNoteViewProps) {
       onSearchTextChange={(value) => {
         props.onSearchChange(value);
       }}
+      searchText={props.searchText}
     >
       <List.Item
         title={`🗒️ Create Note "${props.searchText}"`}

--- a/src/components/NoteList/NoteList.tsx
+++ b/src/components/NoteList/NoteList.tsx
@@ -1,12 +1,14 @@
 import { List, getPreferenceValues } from "@raycast/api";
 import { memo, useMemo, useState } from "react";
+
 import { NoteListProps } from "../../utils/interfaces";
 import { MAX_RENDERED_NOTES } from "../../utils/constants";
 import { NoteListItem } from "./NoteListItem/NoteListItem";
 import { NoteListDropdown } from "./NoteListDropdown";
+import { searchFunction } from "../../utils/search/search";
 import { SearchNotePreferences } from "../../utils/preferences";
+import { SortOrder, sortNotesByOrder } from "../../utils/noteSorter";
 import { CreateNoteView } from "./CreateNoteView";
-import { filterNotesFuzzy } from "../../api/search/search.service";
 
 const MemoizedNoteListItem = memo(NoteListItem);
 
@@ -14,32 +16,49 @@ export function NoteList(props: NoteListProps) {
   const { notes, vault, title, searchArguments, isLoading } = props;
 
   const pref = getPreferenceValues<SearchNotePreferences>();
-  const [inputText, setInputText] = useState(searchArguments.searchArgument || "");
+  const validSortOrders: SortOrder[] = ["az", "za", "mn", "mo", "cn", "co"];
+  const initialSortOrder: SortOrder = validSortOrders.includes(pref.prefSortOrder as SortOrder)
+    ? (pref.prefSortOrder as SortOrder)
+    : "az";
+
+  const [sortOrder, setSortOrder] = useState<SortOrder>(initialSortOrder);
+  const [searchText, setSearchText] = useState(
+    searchArguments?.searchArgument || searchArguments?.initialSearchText || ""
+  );
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
 
-  const filteredNotes = useMemo(() => {
-    if (!inputText.trim()) {
-      return notes.slice(0, MAX_RENDERED_NOTES);
-    }
+  const prefilterSearchQuery = (searchArguments?.prefilterSearchQuery ?? "").trim();
+  const prefilteredNotes = useMemo(
+    () => (prefilterSearchQuery ? searchFunction(notes ?? [], prefilterSearchQuery) : notes ?? []),
+    [notes, prefilterSearchQuery]
+  );
 
-    return filterNotesFuzzy(notes, inputText, false).slice(0, MAX_RENDERED_NOTES);
-  }, [notes, inputText]);
+  const filteredNotes = useMemo(() => searchFunction(prefilteredNotes, searchText), [prefilteredNotes, searchText]);
+  const sortedNotes = useMemo(() => sortNotesByOrder(filteredNotes, sortOrder), [filteredNotes, sortOrder]);
+  const limitedNotes = sortedNotes.slice(0, MAX_RENDERED_NOTES);
+  const trimmedSearchText = searchText.trim();
 
-  if (filteredNotes.length === 0 && inputText.trim() !== "") {
-    return <CreateNoteView title={title || ""} searchText={inputText} onSearchChange={setInputText} vault={vault} />;
+  const searchAccessory = useMemo(
+    () => <NoteListDropdown sortOrder={sortOrder} setSortOrder={setSortOrder} />,
+    [sortOrder]
+  );
+
+  if (limitedNotes.length === 0 && trimmedSearchText) {
+    return <CreateNoteView title={title || ""} searchText={trimmedSearchText} onSearchChange={setSearchText} vault={vault} />;
   }
 
   return (
     <List
       isLoading={isLoading}
-      throttle={true}
+      throttle
       isShowingDetail={pref.showDetail}
-      onSearchTextChange={setInputText}
-      onSelectionChange={setSelectedItemId}
+      onSearchTextChange={setSearchText}
+      searchText={searchText}
       navigationTitle={title}
-      searchBarAccessory={<NoteListDropdown tags={[]} searchArguments={searchArguments} />}
+      onSelectionChange={setSelectedItemId}
+      searchBarAccessory={searchAccessory}
     >
-      {filteredNotes.map((note, idx) => (
+      {limitedNotes.map((note, idx) => (
         <MemoizedNoteListItem
           note={note}
           vault={vault}

--- a/src/components/NoteList/NoteListDropdown.tsx
+++ b/src/components/NoteList/NoteListDropdown.tsx
@@ -1,49 +1,27 @@
-import { List } from "@raycast/api";
-import { useEffect, useState } from "react";
-import { useNotesDispatchContext } from "../../utils/hooks";
-import { SearchArguments } from "../../utils/interfaces";
-import { NoteReducerActionType } from "../../utils/reducers";
+import { List, Icon } from "@raycast/api";
+import { SortOrder } from "../../utils/noteSorter";
 
-export function NoteListDropdown(props: { tags: string[]; searchArguments: SearchArguments }) {
-  const dispatch = useNotesDispatchContext();
-  const { tags, searchArguments } = props;
-
-  const [selectedTag, setSelectedTag] = useState<string>(() => {
-    if (searchArguments.tagArgument) {
-      if (searchArguments.tagArgument.startsWith("#")) {
-        return searchArguments.tagArgument;
-      } else {
-        return "#" + searchArguments.tagArgument;
-      }
-    }
-    return "all";
-  });
-
-  // Apply the filter whenever selectedTag changes or allNotes changes
-  // useEffect(() => {
-  //   if (allNotes) {
-  //     if (selectedTag !== "all") {
-  //       dispatch({
-  //         type: NoteReducerActionType.Set,
-  //         payload: allNotes.filter((note) => note.tags.includes(selectedTag)),
-  //       });
-  //     } else {
-  //       dispatch({ type: NoteReducerActionType.Set, payload: allNotes });
-  //     }
-  //   }
-  // }, [selectedTag, allNotes, dispatch]);
-
-  function handleChange(tag: string) {
-    setSelectedTag(tag);
-  }
+export function NoteListDropdown(props: {
+  sortOrder: SortOrder;
+  setSortOrder: (o: SortOrder) => void;
+}) {
+  const { sortOrder, setSortOrder } = props;
 
   return (
-    <List.Dropdown tooltip="Search For" value={selectedTag} onChange={handleChange}>
-      <List.Dropdown.Item title="All" value="all" />
-      <List.Dropdown.Section title="Tags" />
-      {tags.map((tag: string) => (
-        <List.Dropdown.Item title={tag} value={tag} key={tag} />
-      ))}
+    <List.Dropdown
+      tooltip="Sort Notes"
+      value={sortOrder}
+      onChange={(v) => setSortOrder(v as SortOrder)}
+      storeValue={false}
+    >
+      <List.Dropdown.Section title="Sort Notes">
+        <List.Dropdown.Item value="az" title="File name (A to Z)" icon={Icon.ArrowDown} />
+        <List.Dropdown.Item value="za" title="File name (Z to A)" icon={Icon.ArrowUp} />
+        <List.Dropdown.Item value="mn" title="Modified time (new to old)" icon={Icon.Clock} />
+        <List.Dropdown.Item value="mo" title="Modified time (old to new)" icon={Icon.Clock} />
+        <List.Dropdown.Item value="cn" title="Created time (new to old)" icon={Icon.Calendar} />
+        <List.Dropdown.Item value="co" title="Created time (old to new)" icon={Icon.Calendar} />
+      </List.Dropdown.Section>
     </List.Dropdown>
   );
 }

--- a/src/components/NoteList/NoteListItem/NoteListItem.tsx
+++ b/src/components/NoteList/NoteListItem/NoteListItem.tsx
@@ -108,9 +108,9 @@ export function NoteListItem(props: {
       }
       actions={
         <ActionPanel>
-          <OpenNoteActions note={{ content: noteContent ?? "", ...updatedNote }} vault={vault} />
+          <OpenNoteActions note={{ ...updatedNote, content: noteContent ?? "" }} vault={vault} />
           <NoteActions
-            note={{ content: noteContent ?? "", ...updatedNote }}
+            note={{ ...updatedNote, content: noteContent ?? "" }}
             vault={vault}
             onNoteAction={(actionType) => {
               switch (actionType) {

--- a/src/components/NoteList/NoteListObsidian.tsx
+++ b/src/components/NoteList/NoteListObsidian.tsx
@@ -1,25 +1,38 @@
-import { useNotes } from "../../utils/hooks";
+import React, { useEffect, useReducer } from "react";
+
+import { NotesContext, NotesDispatchContext, useNotes } from "../../utils/hooks";
 import { SearchArguments } from "../../utils/interfaces";
 import { NoteList } from "./NoteList";
+import { NoteReducer, NoteReducerActionType } from "../../utils/reducers";
 import { Vault } from "../../api/vault/vault.types";
 
 export const NoteListObsidian = function NoteListObsidian(props: {
   vault: Vault;
   showTitle: boolean;
-  bookmarked: boolean;
+  bookmarked?: boolean;
   searchArguments: SearchArguments;
 }) {
   const { showTitle, vault, searchArguments, bookmarked } = props;
 
-  const { notes, loading } = useNotes(vault, bookmarked);
+  const { notes: allNotes, loading } = useNotes(vault, bookmarked);
+  const [currentViewNoteList, dispatch] = useReducer(NoteReducer, allNotes);
+
+  // Keep reducer state in sync when the underlying notes change
+  useEffect(() => {
+    dispatch({ type: NoteReducerActionType.Set, payload: allNotes });
+  }, [allNotes]);
 
   return (
-    <NoteList
-      title={showTitle ? `Search Note in ${vault.name}` : ""}
-      notes={notes}
-      vault={vault}
-      searchArguments={searchArguments}
-      isLoading={loading}
-    />
+    <NotesContext.Provider value={allNotes}>
+      <NotesDispatchContext.Provider value={dispatch}>
+        <NoteList
+          title={showTitle ? `Search Note in ${vault.name}` : ""}
+          notes={currentViewNoteList}
+          vault={vault}
+          searchArguments={searchArguments}
+          isLoading={loading}
+        />
+      </NotesDispatchContext.Provider>
+    </NotesContext.Provider>
   );
 };

--- a/src/components/VaultSelection.tsx
+++ b/src/components/VaultSelection.tsx
@@ -1,6 +1,6 @@
 import { List, ActionPanel, Action } from "@raycast/api";
 import { Vault } from "../api/vault/vault.types";
-import { ReactNode } from "@raycast/api/node_modules/@types/react";
+import { ReactNode } from "react";
 import { ShowVaultInFinderAction } from "../utils/actions";
 
 export function VaultSelection(props: { vaults: Vault[]; target: (vault: Vault) => ReactNode }) {

--- a/src/importantNotesCommand.tsx
+++ b/src/importantNotesCommand.tsx
@@ -1,4 +1,4 @@
-import { List } from "@raycast/api";
+import { List, getPreferenceValues } from "@raycast/api";
 
 import { NoteListObsidian } from "./components/NoteList/NoteListObsidian";
 import { VaultSelection } from "./components/VaultSelection";
@@ -7,9 +7,14 @@ import { NoVaultFoundMessage } from "./components/Notifications/NoVaultFoundMess
 import { noVaultPathsToast } from "./components/Toasts";
 import { useObsidianVaults } from "./utils/hooks";
 import { Vault } from "./api/vault/vault.types";
+import { SearchNotePreferences } from "./utils/preferences";
 
 export default function Command(props: { arguments: SearchArguments }) {
   const { ready, vaults } = useObsidianVaults();
+  const pref = getPreferenceValues<SearchNotePreferences>();
+  const prefilterSearchQuery = pref.prefilterSearchQuery;
+  const prefilter = prefilterSearchQuery?.trim() ? prefilterSearchQuery.trim() : "";
+  props.arguments.prefilterSearchQuery = prefilter || undefined;
 
   if (!ready) {
     return <List isLoading={true} />;
@@ -20,12 +25,12 @@ export default function Command(props: { arguments: SearchArguments }) {
       <VaultSelection
         vaults={vaults}
         target={(vault: Vault) => (
-          <NoteListObsidian vault={vault} showTitle={true} bookmarked={true} searchArguments={props.arguments} />
+          <NoteListObsidian vault={vault} showTitle={true} searchArguments={props.arguments} />
         )}
       />
     );
   } else if (vaults.length == 1) {
-    return <NoteListObsidian vault={vaults[0]} showTitle={false} bookmarked={true} searchArguments={props.arguments} />;
+    return <NoteListObsidian vault={vaults[0]} showTitle={false} searchArguments={props.arguments} />;
   } else {
     noVaultPathsToast();
   }

--- a/src/obsidianMenuBar.tsx
+++ b/src/obsidianMenuBar.tsx
@@ -8,6 +8,7 @@ import { getObsidianTarget, ObsidianTargetType } from "./utils/utils";
 
 function BookmarkedNotesList(props: { vault: Vault }) {
   const notes: Note[] = [];
+  // const [notes] = useNotes(props.vault); # TODO: My incoming change. Test the difference.
   return (
     <MenuBarExtra.Submenu title={props.vault.name} key={props.vault.path + "Bookmarked Notes"}>
       {notes.map((note) => (

--- a/src/searchNoteCommand.tsx
+++ b/src/searchNoteCommand.tsx
@@ -1,4 +1,4 @@
-import { List } from "@raycast/api";
+import { List, getPreferenceValues } from "@raycast/api";
 
 import { NoteListObsidian } from "./components/NoteList/NoteListObsidian";
 import { VaultSelection } from "./components/VaultSelection";
@@ -7,9 +7,14 @@ import { NoVaultFoundMessage } from "./components/Notifications/NoVaultFoundMess
 import { noVaultPathsToast } from "./components/Toasts";
 import { useObsidianVaults } from "./utils/hooks";
 import { Vault } from "./api/vault/vault.types";
+import { SearchNotePreferences } from "./utils/preferences";
 
 export default function Command(props: { arguments: SearchArguments }) {
   const { ready, vaults } = useObsidianVaults();
+  const pref = getPreferenceValues<SearchNotePreferences>();
+  const initialSearchText = pref.initialSearchText;
+  const initial = initialSearchText?.trim() ? initialSearchText.trim() : "";
+  props.arguments.initialSearchText = initial || undefined;
 
   if (!ready) {
     return <List isLoading={true} />;
@@ -20,13 +25,13 @@ export default function Command(props: { arguments: SearchArguments }) {
       <VaultSelection
         vaults={vaults}
         target={(vault: Vault) => (
-          <NoteListObsidian vault={vault} showTitle={true} bookmarked={false} searchArguments={props.arguments} />
+          <NoteListObsidian vault={vault} showTitle={true} searchArguments={props.arguments} />
         )}
       />
     );
   } else if (vaults.length == 1) {
     return (
-      <NoteListObsidian vault={vaults[0]} showTitle={false} bookmarked={false} searchArguments={props.arguments} />
+      <NoteListObsidian vault={vaults[0]} showTitle={false} searchArguments={props.arguments} />
     );
   } else {
     noVaultPathsToast();

--- a/src/utils/actions.tsx
+++ b/src/utils/actions.tsx
@@ -338,6 +338,7 @@ export function NoteActions(props: {
       <AppendSelectedTextToNoteAction note={note} vault={vault} />
       <CopyNoteAction note={note} />
       <CopyNoteTitleAction note={note} />
+      <CopyNoteJDexFromTitleAction note={note} />
       <PasteNoteAction note={note} />
       <CopyMarkdownLinkAction note={note} />
       <CopyObsidianURIAction note={note} />
@@ -419,5 +420,17 @@ export function AppendTaskAction(props: { note: Note; vault: Vault }) {
       shortcut={{ modifiers: ["opt"], key: "a" }}
       icon={Icon.Pencil}
     />
+  );
+}
+
+export function CopyNoteJDexFromTitleAction(props: { note: Note }) {
+  const { note } = props;
+  const title = note.title;
+  const index = title.indexOf("_");
+  const substring = index !== -1 ? title.substring(0, index) : title;
+  const formattedSubstring = `[${substring}]`;
+
+  return (
+    <Action.CopyToClipboard title="Copy JDex From Title" content={formattedSubstring} shortcut={{ modifiers: ["opt"], key: "j" }} />
   );
 }

--- a/src/utils/folderPaths.tsx
+++ b/src/utils/folderPaths.tsx
@@ -1,0 +1,40 @@
+import fs from "fs";
+import path from "path";
+import { getPreferenceValues } from "@raycast/api";
+import { Vault } from "../api/vault/vault.types";
+import { isPathExcluded, getUserIgnoreFilters, DEFAULT_EXCLUDED_PATHS } from "../api/vault/vault.service";
+
+function walkDirsHelper(pathToWalk: string, excludedFolders: string[], vaultRoot: string, collected: Set<string>): Set<string> {
+  const files = fs.readdirSync(pathToWalk);
+  const { configFileName } = getPreferenceValues();
+
+  for (const file of files) {
+    const fullPath = path.join(pathToWalk, file);
+    const stats = fs.statSync(fullPath);
+
+    if (stats.isDirectory()) {
+      if (file === configFileName) continue;
+      if (DEFAULT_EXCLUDED_PATHS.includes(file)) continue;
+      if (isPathExcluded(fullPath, excludedFolders, vaultRoot)) continue;
+
+      collected.add(fullPath);
+      walkDirsHelper(fullPath, excludedFolders, vaultRoot, collected);
+    }
+  }
+  return collected;
+}
+
+export function getAllFolderPaths(vault: Vault): string[] {
+  const preferences = getPreferenceValues<{ excludedFolders?: string }>();
+  const excludedFolders = preferences.excludedFolders ? preferences.excludedFolders.split(",") : [];
+  const userIgnoredFolders = getUserIgnoreFilters(vault);
+  excludedFolders.push(...userIgnoredFolders);
+
+  const collected = walkDirsHelper(vault.path, excludedFolders, vault.path, new Set<string>());
+
+  const relative = Array.from(collected)
+    .map((p) => path.relative(vault.path, p))
+    .filter((p) => p && p.trim() !== "");
+
+  return relative.sort();
+}

--- a/src/utils/hooks.tsx
+++ b/src/utils/hooks.tsx
@@ -48,6 +48,12 @@ export function useNotes(vault: Vault, bookmarked = false) {
   return { notes: filtered, loading } as const;
 }
 
+export const NotesContext = createContext([] as Note[]);
+
+export function useNotesContext() {
+  return useContext(NotesContext);
+}
+
 export function useNotesDispatchContext() {
   return useContext(NotesDispatchContext);
 }

--- a/src/utils/interfaces.tsx
+++ b/src/utils/interfaces.tsx
@@ -3,8 +3,9 @@ import { Note } from "../api/vault/notes/notes.types";
 import { Vault } from "../api/vault/vault.types";
 
 export interface SearchArguments {
-  searchArgument?: string;
-  tagArgument?: string;
+  searchArgument: string;
+  prefilterSearchQuery?: string;
+  initialSearchText?: string;
 }
 
 export interface Media {
@@ -29,7 +30,7 @@ export interface NoteListProps {
   notes: Note[];
   isLoading?: boolean;
   searchArguments: SearchArguments;
-  action?: (note: Note, vault: Vault) => React.ReactFragment;
+  action?: (note: Note, vault: Vault) => React.ReactNode;
   onDelete?: (note: Note, vault: Vault) => void;
   onSearchChange?: (search: string) => void;
 }

--- a/src/utils/noteSorter.tsx
+++ b/src/utils/noteSorter.tsx
@@ -1,0 +1,36 @@
+export type SortOrder = "az" | "za" | "mn" | "mo" | "cn" | "co";
+
+// This function handles file dates as both Date objects and strings representing dates.
+// This ensures robustness against possible changes to the created and modified attributes in notes,
+// such as adjustments made in LoadNotes (vault.service).
+export function sortNotesByOrder<T extends { title?: string; created?: Date | string | number; modified?: Date | string | number }>(
+  notes: T[],
+  order: SortOrder
+): T[] {
+  const safeTitle = (n: T) => (n.title ?? "").trim();
+  const ts = (d?: Date | string | number) => {
+    if (d instanceof Date) return d.getTime();
+    if (typeof d === "number") return Number.isFinite(d) ? d : 0;
+    if (typeof d === "string") {
+      const t = Date.parse(d);
+      return Number.isNaN(t) ? 0 : t;
+    }
+    return 0;
+  };
+  const arr = [...notes]; // never mutate caller
+
+  switch (order) {
+    case "az":
+      return arr.sort((a, b) => safeTitle(a).localeCompare(safeTitle(b), undefined, { sensitivity: "base", numeric: true }));
+    case "za":
+      return arr.sort((a, b) => safeTitle(b).localeCompare(safeTitle(a), undefined, { sensitivity: "base", numeric: true }));
+    case "mn":
+      return arr.sort((a, b) => ts(b.modified) - ts(a.modified));
+    case "mo":
+      return arr.sort((a, b) => ts(a.modified) - ts(b.modified));
+    case "cn":
+      return arr.sort((a, b) => ts(b.created) - ts(a.created));
+    case "co":
+      return arr.sort((a, b) => ts(a.created) - ts(b.created));
+  }
+}

--- a/src/utils/preferences.tsx
+++ b/src/utils/preferences.tsx
@@ -4,7 +4,8 @@ export interface GlobalPreferences {
   removeYAML: boolean;
   removeLinks: boolean;
   removeLatex: boolean;
-  excludedFolders: string;
+  excludedPatterns: string;
+  includedPatterns: string;
 }
 
 export interface AppendNotePreferences {
@@ -17,19 +18,31 @@ export interface NoteFormPreferences extends GlobalPreferences {
   prefNoteName: string;
   prefNoteContent: string;
   fillFormWithDefaults: boolean;
-  prefTag: string;
-  tags: string;
+  defaultTags: string;
+  defaultKeys: string;
   openOnCreate: boolean;
   folderActions: string;
   focusContentArea: boolean;
+  prefEnableJDex: boolean;
+  jdexRootTag: string;
+  jdexTitleSeparator: string;
 }
 
 export interface SearchNotePreferences extends GlobalPreferences, AppendNotePreferences {
   primaryAction: string;
   showDetail: boolean;
   showMetadata: boolean;
-  searchContent: boolean;
   fuzzySearch: boolean;
+  prefSearchMode: string;
+  prefSearchScope: string;
+  userDefinedSearchScope: string;
+  prefLunrSearchOrder: boolean;
+  prefSortOrder: string;
+  prefLogicMode: string;
+  yamlProperties: string;
+  initialSearchText: string;
+  prefilterSearchQuery: string;
+  prefNoteName: string;
 }
 
 export interface RandomNotePreferences extends GlobalPreferences, AppendNotePreferences {}

--- a/src/utils/search/README.md
+++ b/src/utils/search/README.md
@@ -1,0 +1,233 @@
+## Query Syntax Principles
+
+An input search query is parsed into `field:value` pairs. Special tokens include `"`, `:`, `(`, `)`, `AND`, `OR`, `-` (NOT), and `~` (fuzzy operator). Values without a specified field are assigned to the default field. Single characters like `:`, `-`, and `~` are treated as literals unless specified otherwise. For comparisons, strings are normalized by trimming leading and trailing whitespace and converting to lowercase, except when using regular expressions (`/.../flags`), where flags are preserved.
+
+### Rule 1: Token Separation
+
+The raw query string is split by quotes, whitespace, and certain punctuation characters (`(`, `)`, `:`, `-`, `~`). Quotes (`"`) take precedence over whitespace, so anything inside balanced quotes is preserved as a single unit. An opening quote without a matching closing quote is treated as a literal character. Escaped quotes (`\"`) are parsed as literal quotes.
+
+**Example:**
+
+The query:
+
+```
+abc "def"g" "hi jk"
+```
+
+is parsed as:
+
+```json
+[
+  { "field": "default", "value": "abc" },
+  { "field": "default", "value": "def" },
+  { "field": "default", "value": "g" },
+  { "field": "default", "value": " " },
+  { "field": "default", "value": "hi" },
+  { "field": "default", "value": "jk\"" }
+]
+```
+
+**Examples:**
+
+### Rule 2: Field-Value Parsing
+
+- A field name is whatever appears before the first occurrence of `:` in a string. (If the colon appears at the start of the term, it is treated literally rather than as a field separator.)
+- The value begins immediately after that colon and continues until the next whitespace.
+- If the value starts with a quote immediately after the colon, it ends at the matching closing quote (or, if missing, at the next whitespace).
+- If the value starts with a parenthesis, it ends at the matching closing parenthesis (or, if missing, the entire expression is invalid).
+
+**Examples**
+
+- Query:
+
+  ```
+  key::val1-:~) abc
+  ```
+
+  is parsed as:
+
+  ```json
+  [
+    { "field": "key", "value": ":val1-:~)" },
+    { "field": "default", "value": "abc" }
+  ]
+  ```
+- Query:
+
+  ```
+  key:"abc def"
+  ```
+
+  is parsed as:
+
+  ```json
+  [
+    { "field": "key", "value": "abc def" }
+  ]
+  ```
+- Query with missing closing quote:
+
+  ```
+  key:"abc \"def
+  ```
+
+  is parsed as:
+
+  ```json
+  [
+    { "field": "key", "value": "\"abc" },
+    { "field": "default", "value": "\"def" }
+  ]
+  ```
+
+### Rule 3: Tilde (`~`) as Fuzzy Operator
+
+The tilde (**~**) acts as a suffix fuzzy marker only when it appears immediately after a term or a quoted phrase (no whitespace).
+
+**Exmaples**:
+
+- `abc~`
+- `key:abc~`
+- `"abc def"~`
+- `key:"abc def"~`
+
+**Scope and propagation:** When a term is marked fuzzy, that property stays with the term wherever it appears (inside parentheses, under `-`/`AND`/`OR`, or within `field:(...)` groups). Fuzziness applies to the field value being evaluated at that point.
+
+**In all other cases, tilde is treated as a literal character.**
+
+- `~`
+- `key:~`
+- `~key:abc`
+
+#### Edge Cases
+
+- Regular expressions are not eligible for fuzziness. A regex followed by `~` (e.g., `/regex/~` or `key:/regex/~`) is treated as a non-match and does not affect the rest of the query.
+- An empty quoted term with `~` (e.g.,`""~`or `key:""~`) also results in a non-match.
+
+### Rule 4: Hyphen (`-`) as Unary Operator
+
+A hyphen (`-`) is treated as a unary NOT operator only when it starts a string longer than one character.
+
+**Examples:**
+
+- `-abc`
+- `-key:`
+- `-key:abc`
+- `-"abc def"`
+- `-(...)`
+- `-/regex/`
+
+**In all other cases, hyphen is treated as a literal character.**
+
+**Examples:**
+
+- `-`
+- `01-`
+- `key:-abc`
+
+### Rule 5: Regular Expressions
+
+Regular expressions are supported when enclosed in slashes. Optional flags are allowed.
+
+- `/regex/flags`
+- `key:/regex/flags`
+
+If flags include anything outside **gimsyu**, `/regex/flags` yields zero hits.
+
+### Rule 6: Field Presence and Value Queries
+
+- For most frontmatter fields (for example `status` or `meta`):
+  - `field:` matches notes where the field exists, regardless of whether the value is empty.
+  - `field:""` matches notes where the field exists and is empty (after trimming whitespace).
+  - `field:any` matches notes where the field exists and contains a non-empty value.
+- `aliases` and `locations` behave the same way as above even though they are normalised to arrays during load. When their array is empty, the evaluator falls back to the raw frontmatter to determine presence, so:
+  - `aliases:` / `locations:` match notes where the respective key is defined in YAML (including empty arrays or strings).
+  - `aliases:""` / `locations:""` match notes where the key exists and is explicitly empty.
+  - `aliases:any` / `locations:any` require at least one non-empty value.
+- `tag:#foo` is normalized to `tag:foo` (hash stripped for compatibility with Obsidian) and matches tags exactly.
+- `tags:foo` performs a partial match across tag values (case-insensitive substring). Use this when you want to match nested tags without writing regex.
+- `field:( ... )` scopes the nested query to that field. The clauses inside the parentheses are evaluated against each individual value for the field, and a note matches only if a single value satisfies the entire inner expression. For example:
+  - `tag:(foo OR bar)` matches notes that have at least one tag equal to `foo` or `bar`.
+  - `locations:(Main Raindrop)` matches notes where one `locations` value contains both `Main` and `Raindrop` together (different entries cannot satisfy the terms independently).
+  - `locations:(Main -Raindrop)` keeps entries that include `Main` while excluding those that also contain `Raindrop`.
+    Fuzzy terms (e.g. `term~`) and regexes inside the group operate on that same single value.
+- Virtual fields (see the list below) treat `field:` the same as `field:any`, ignore `field:""`, and honour `field:any`. The only exceptions are `aliases` and `locations`, which use the frontmatter fallback described above so that presence queries can distinguish between “missing” and “defined but empty”.
+- `bookmarked:` and `bookmarked:any` return bookmarked notes; `bookmarked:""` and `bookmarked:false` yield no matches. `bookmarked:true` is supported for explicit checks.
+
+**Hint:** Whitespace-only field values are trimmed and treated as undefined.
+
+### Rule 7: Virtual Fields
+
+The fields listed below are always present in every note (though their values may be empty).
+
+- `title`
+- `file`
+- `path`
+- `created`
+- `modified`
+- `tag`
+- `tags`
+- `content`
+- `bookmarked`
+- `anyname`
+- `full`
+- `aliases`
+- `locations`
+
+For these virtual fields except for `locations` and `aliases`, `field:` behaves like `field:any`, and `field:""` yields no results.
+
+#### Virtual Fields Not Implemented
+
+Obsidian also recognises additional virtual helpers such as:
+
+- `line`
+- `block`
+- `section`
+- `task`
+- `task-todo`
+- `task-done`
+- `match-case`
+- `ignore-case`
+
+These modifiers are **not** currently supported in this Raycast search pipeline; queries that reference them fall back to plain text matching and will not mirror Obsidian’s behaviour.
+
+### Rule 8: Special Handling of `Bookmarked` Field
+
+Every note includes a `bookmarked` field, set to either `true` or `false`.
+
+- `bookmarked:` → same as `bookmarked:true`
+- `bookmarked:any` → same as `bookmarked:true`
+- `bookmarked:""` → never matches
+- `bookmarked:false` → never matches (treated as if absent)
+
+### Validation
+
+In these cases, the query is considered invalid and will not be passed to the parser:
+
+- **UNBALANCED_PARENS** — Occurs when opening and closing parentheses `(` and `)` are not balanced.
+
+  **Examples (invalid):**
+
+  ```
+  (abc OR def  
+  abc) AND (def  
+  (abc AND (def  
+  ```
+- **DANGLING_OPERATOR** — Occurs when a binary logical operator such as `AND` or `OR` appears without a valid term on one side.
+
+  **Examples (invalid):**
+
+  ```
+  AND abc  
+  abc OR   
+  abc AND OR def  
+  ```
+- **UNFINISHED_REGEX** — Occurs when a regular expression starts with `/` but has no closing `/` (with optional flags).
+
+  **Examples (invalid):**
+
+  ```
+  /abc   
+  key:/tag(.*  
+  /"unterminated  
+  ```

--- a/src/utils/search/__tests__/evaluator.spec.ts
+++ b/src/utils/search/__tests__/evaluator.spec.ts
@@ -1,0 +1,380 @@
+import { parseQuery } from '../parser';
+import { evaluateQueryAST, type EvaluateOptions } from '../evaluator';
+// at top of evaluate.spec.ts (or wherever your fixtures live)
+import { type Doc } from '../evaluator';
+
+export const DOC_BASE: Doc = {
+    id: '/Users/exampleuser/JD/85-89_Test-Area-2/85_Test/85.10_Test/testme7.md',
+    index: '[[85.10_Test]]',
+    created: new Date('2025-09-04T22:37:26.956Z'),
+    modified: new Date('2025-09-04T22:41:28.544Z'),
+    test: 'ab "c',
+    title: 'testme7',
+    path: '/Users/exampleuser/JD/85-89_Test-Area-2/85_Test/85.10_Test/testme7.md',
+    tags: [],
+    content:
+        '---\n' +
+        'index: "[[85.10_Test]]"\n' +
+        'created: \n' +
+        'modified: \n' +
+        'test: ma "b\n' +
+        '---',
+    bookmarked: false,
+    aliases: [],
+    locations: [],
+} as const;
+
+// Create numbered variants from the base fixture for focused tests
+const variant = (n: number, overrides: Partial<Doc> = {}): Doc => {
+    const num = String(n).padStart(2, "0"); // pad to 2 digits, adjust as needed
+    return {
+        ...DOC_BASE,
+        id: DOC_BASE.id.replace(/testme\d+\.md$/, `testme${num}.md`),
+        title: `testme${num}`,
+        ...overrides,
+    };
+};
+
+export const DOC_TESTME1 = variant(1); // base as-is
+export const DOC_TESTME2 = variant(2, { test: 'hello"world' });
+export const DOC_TESTME3 = variant(3, { tags: ['custom'] });
+export const DOC_TESTME4 = variant(4, { tags: [] });
+export const DOC_TESTME5 = variant(5, { title: 'reABC' }); // for regex test
+export const DOC_TESTME6 = variant(6, { key: 'abc def' } as any); // fielded quoted value
+export const DOC_TESTME7 = variant(7, { content: ':test' }); // literal ':'
+export const DOC_TESTME8 = variant(8, { bookmarked: true });
+export const DOC_TESTME9 = variant(9, { test: '~' });
+export const DOC_TESTME10 = variant(10, { test: 'abc', content: 'x y' });
+export const DOC_TESTME11 = variant(11, { content: ' x ' });
+export const DOC_TESTME12 = variant(12, { tag: ['foo', 'bar'] } as any);
+export const DOC_TESTME13 = variant(13, { tag: ['baz'] } as any);
+export const DOC_TESTME14 = variant(14, { tags: ['alpha'], title: 'RegexNote.md' });
+export const DOC_TESTME15 = variant(15, { tags: ['work', 'foo'] });
+export const DOC_TESTME16 = variant(16, { tags: ['workshop'] });
+export const DOC_TESTME17 = variant(17, { tags: ['nested/work'] });
+export const DOC_TESTME18 = variant(18, { title: '', tags: [] });
+export const DOC_TESTME19 = variant(19, { meta: 'value' } as any);
+export const DOC_TESTME20 = variant(20, { meta: '' } as any);
+export const DOC_TESTME21 = variant(21, { locations: ['Main Raindrop', 'Secondary'] });
+export const DOC_TESTME22 = variant(22, { locations: ['Main Garden', 'Raindrop Alley'] });
+export const DOC_TESTME23 = variant(23, { locations: ['Main Street', 'Gallery'] });
+export const DOC_TESTME24 = variant(24, { locations: ['Garden Walk'] });
+export const DOC_TESTME25 = variant(25, {
+    content:
+        '---\n' +
+        'aliases: []\n' +
+        '---\n',
+    aliases: [],
+});
+export const DOC_TESTME26 = variant(26, {
+    content:
+        '---\n' +
+        'aliases:\n' +
+        '  - Alt Name\n' +
+        '---\n',
+    aliases: ['Alt Name'],
+});
+export const DOC_TESTME27 = variant(27, {
+    content:
+        '---\n' +
+        'locations: []\n' +
+        '---\n',
+    locations: [],
+});
+export const DOC_TESTME28 = variant(28, {
+    content:
+        '---\n' +
+        'locations:\n' +
+        '  - Plaza\n' +
+        '---\n',
+    locations: ['Plaza'],
+});
+
+const mkDoc = (base: Doc, overrides: Partial<Doc> = {}): Doc => ({
+    ...base,
+    ...overrides,
+});
+
+const TEST_OPTS = {
+    defaultFields: ['title'],
+} as const satisfies EvaluateOptions;
+
+describe('evaluate', () => {
+    it('matches fielded phrase with escaped quote (DOC_TESTME1)', () => {
+        const ast = parseQuery('test:"ab \\"c"');
+        const doc = mkDoc(DOC_TESTME1);
+        const res = evaluateQueryAST(ast, [doc], TEST_OPTS);
+        expect(res.hits.map(h => h.id)).toContain(doc.id);
+    });
+
+    it('matches when a double quote is included in key "test" value (DOC_TESTME2)', () => {
+        const ast = parseQuery('test:hello"world');
+        const doc = mkDoc(DOC_TESTME2);
+        const res = evaluateQueryAST(ast, [doc], TEST_OPTS);
+        expect(res.hits.map(h => h.id)).toContain(doc.id);
+    });
+
+    it('matches a document with a custom tag (DOC_TESTME3)', () => {
+        const ast = parseQuery('tags:custom');
+        const doc = mkDoc(DOC_TESTME3);
+        const res = evaluateQueryAST(ast, [doc], TEST_OPTS);
+        expect(res.hits.map(h => h.id)).toContain(doc.id);
+    });
+
+    it('does not match empty tags via tags:"" (DOC_TESTME4)', () => {
+        const ast = parseQuery('tags:""');
+        const doc = mkDoc(DOC_TESTME4);
+        const res = evaluateQueryAST(ast, [doc], TEST_OPTS);
+        expect(res.hits).toHaveLength(0);
+    });
+
+    it('regex literal matches (DOC_TESTME5)', () => {
+        const ast = parseQuery('/re*/i');
+        const doc = mkDoc(DOC_TESTME5);
+        const res = evaluateQueryAST(ast, [doc], TEST_OPTS);
+        expect(res.hits.map(h => h.id)).toContain(doc.id);
+    });
+
+    it('fielded quoted value after colon (DOC_TESTME6)', () => {
+        const ast = parseQuery('key:"abc def"');
+        const doc = mkDoc(DOC_TESTME6);
+        const res = evaluateQueryAST(ast, [doc], TEST_OPTS);
+        expect(res.hits.map(h => h.id)).toContain(doc.id);
+    });
+
+    it('treats a leading colon as a literal in a fielded value (DOC_TESTME7)', () => {
+        const ast = parseQuery('content::test');
+        const doc = mkDoc(DOC_TESTME7);
+        const res = evaluateQueryAST(ast, [doc], TEST_OPTS);
+        expect(res.hits.map(h => h.id)).toContain(doc.id);
+    });
+
+    it('treats bookmarked:any same as bookmarked:true (DOC_TESTME8)', () => {
+        const doc = mkDoc(DOC_TESTME8);
+        const ast = parseQuery('bookmarked:any');
+        const res = evaluateQueryAST(ast, [doc], TEST_OPTS);
+        expect(res.hits.map(h => h.id)).toContain(doc.id);
+    });
+
+    it('bookmarked presence operators behave consistently', () => {
+        const bookmarkedDoc = mkDoc(DOC_TESTME8);
+        const unbookmarkedDoc = mkDoc(DOC_TESTME1);
+
+        const queries = ['bookmarked:', 'bookmarked:any', 'bookmarked:true'];
+        for (const q of queries) {
+            const res = evaluateQueryAST(parseQuery(q), [bookmarkedDoc, unbookmarkedDoc], TEST_OPTS);
+            const ids = res.hits.map(h => h.id);
+            expect(ids).toContain(bookmarkedDoc.id);
+            expect(ids).not.toContain(unbookmarkedDoc.id);
+        }
+        const emptyQuoted = evaluateQueryAST(parseQuery('bookmarked:""'), [bookmarkedDoc, unbookmarkedDoc], TEST_OPTS);
+        expect(emptyQuoted.hits).toHaveLength(0);
+        const falseRes = evaluateQueryAST(parseQuery('bookmarked:false'), [bookmarkedDoc, unbookmarkedDoc], TEST_OPTS);
+        expect(falseRes.hits).toHaveLength(0);
+    });
+
+    it('match single ~ in field "field" (DOC_TESTME9)', () => {
+        const ast = parseQuery('test:~');
+        const doc = mkDoc(DOC_TESTME9);
+        const res = evaluateQueryAST(ast, [doc], TEST_OPTS);
+        expect(res.hits.map(h => h.id)).toContain(doc.id);
+    });
+
+    it('complex negation and OR grouping (DOC_TESTME10)', () => {
+        const ast = parseQuery('-( title:test3 OR -test:abc )');
+        const doc = mkDoc(DOC_TESTME10);
+        const res = evaluateQueryAST(ast, [doc], TEST_OPTS);
+        expect(res.hits.map(h => h.id)).toContain(doc.id);
+    });
+
+    it('match quoted whitespace (DOC_TESTME10)', () => {
+        const ast = parseQuery('test:abc content:" "');
+        const doc = mkDoc(DOC_TESTME10);
+        const res = evaluateQueryAST(ast, [doc], TEST_OPTS);
+        expect(res.hits.map(h => h.id)).toContain(doc.id);
+    });
+
+    it('show whitespaces are trimmed (DOC_TESTME10)', () => {
+        const ast = parseQuery('-content:" "');
+        const doc = mkDoc(DOC_TESTME11);
+        const res = evaluateQueryAST(ast, [doc], TEST_OPTS);
+        expect(res.hits.map(h => h.id)).toContain(doc.id);
+    });
+
+    it('evaluates field-scoped groups (DOC_TESTME12, DOC_TESTME13)', () => {
+        const ast = parseQuery('tag:(foo OR qux)');
+        const docMatch = mkDoc(DOC_TESTME12);
+        const docMiss = mkDoc(DOC_TESTME13);
+        const res = evaluateQueryAST(ast, [docMatch, docMiss], { ...TEST_OPTS, defaultFields: ['title'], fieldMap: { tag: (d) => (d as any).tag } });
+        const hitIds = res.hits.map(h => h.id);
+        expect(hitIds).toContain(docMatch.id);
+        expect(hitIds).not.toContain(docMiss.id);
+    });
+
+    it('requires AND clauses inside a field group to match the same entry (DOC_TESTME21, DOC_TESTME22)', () => {
+        const docs = [mkDoc(DOC_TESTME21), mkDoc(DOC_TESTME22)];
+        const res = evaluateQueryAST(parseQuery('locations:(Main Raindrop)'), docs, TEST_OPTS);
+        const ids = res.hits.map(h => h.id);
+        expect(ids).toContain(docs[0].id);
+        expect(ids).not.toContain(docs[1].id);
+    });
+
+    it('evaluates OR inside a field group per entry (DOC_TESTME21, DOC_TESTME24)', () => {
+        const docs = [mkDoc(DOC_TESTME21), mkDoc(DOC_TESTME24)];
+        const res = evaluateQueryAST(parseQuery('locations:(Main OR Raindrop)'), docs, TEST_OPTS);
+        const ids = res.hits.map(h => h.id);
+        expect(ids).toContain(docs[0].id);
+        expect(ids).not.toContain(docs[1].id);
+    });
+
+    it('applies NOT clauses within a field group to the same entry (DOC_TESTME21, DOC_TESTME22, DOC_TESTME23)', () => {
+        const docs = [mkDoc(DOC_TESTME22), mkDoc(DOC_TESTME21), mkDoc(DOC_TESTME23)];
+        const res = evaluateQueryAST(parseQuery('locations:(Main -Raindrop)'), docs, TEST_OPTS);
+        const ids = res.hits.map(h => h.id);
+        expect(ids).toContain(docs[0].id);
+        expect(ids).toContain(docs[2].id);
+        expect(ids).not.toContain(docs[1].id);
+    });
+
+    it('matches regex on default fields (DOC_TESTME14)', () => {
+        const ast = parseQuery('/RegexNote/');
+        const doc = mkDoc(DOC_TESTME14);
+        const res = evaluateQueryAST(ast, [doc], { ...TEST_OPTS, defaultFields: ['title'] });
+        expect(res.hits.map(h => h.id)).toContain(doc.id);
+    });
+
+    it('matches regex with flags on explicit field (DOC_TESTME14)', () => {
+        const ast = parseQuery('file:/regexnote/i');
+        const doc = mkDoc(DOC_TESTME14);
+        const res = evaluateQueryAST(ast, [doc], { ...TEST_OPTS, defaultFields: ['title'], fieldMap: { file: (d) => d.title } });
+        expect(res.hits.map(h => h.id)).toContain(doc.id);
+    });
+
+    it('matches regex against tag field (DOC_TESTME12)', () => {
+        const ast = parseQuery('tag:/fo+/');
+        const doc = mkDoc(DOC_TESTME12);
+        const res = evaluateQueryAST(ast, [doc], { ...TEST_OPTS, defaultFields: ['title'], fieldMap: { tag: (d) => (d as any).tag } });
+        expect(res.hits.map(h => h.id)).toContain(doc.id);
+    });
+
+    it('matches tag field exactly (DOC_TESTME15)', () => {
+        const ast = parseQuery('tag:work');
+        const doc = mkDoc(DOC_TESTME15);
+        const res = evaluateQueryAST(ast, [doc], { ...TEST_OPTS, defaultFields: ['title'], fieldMap: { tag: (d) => (d as any).tags } });
+        expect(res.hits.map(h => h.id)).toContain(doc.id);
+    });
+
+    it('does not treat tag field as substring (DOC_TESTME16)', () => {
+        const ast = parseQuery('tag:work');
+        const doc = mkDoc(DOC_TESTME16);
+        const res = evaluateQueryAST(ast, [doc], { ...TEST_OPTS, defaultFields: ['title'], fieldMap: { tag: (d) => (d as any).tags } });
+        expect(res.hits.map(h => h.id)).not.toContain(doc.id);
+    });
+
+    it('matches tags field partially (DOC_TESTME16, DOC_TESTME17)', () => {
+        const ast = parseQuery('tags:work');
+        const docs = [mkDoc(DOC_TESTME16), mkDoc(DOC_TESTME17)];
+        const res = evaluateQueryAST(ast, docs, { ...TEST_OPTS, defaultFields: ['title'], fieldMap: { tags: (d) => (d as any).tags } });
+        const hitIds = res.hits.map(h => h.id);
+        expect(hitIds).toContain(docs[0].id);
+        expect(hitIds).toContain(docs[1].id);
+    });
+
+    it('file: behaves like file:any for virtual title (DOC_TESTME15, DOC_TESTME18)', () => {
+        const ast = parseQuery('file:');
+        const docs = [mkDoc(DOC_TESTME15), mkDoc(DOC_TESTME18)];
+        const opts = { ...TEST_OPTS, defaultFields: ['title'], fieldMap: { file: (d) => d.title } } satisfies EvaluateOptions;
+        const res = evaluateQueryAST(ast, docs, opts);
+        const ids = res.hits.map(h => h.id);
+        expect(ids).toContain(docs[0].id);
+        expect(ids).not.toContain(docs[1].id);
+    });
+
+    it('tags: behaves like tags:any for virtual tags (DOC_TESTME3, DOC_TESTME4)', () => {
+        const ast = parseQuery('tags:');
+        const docs = [mkDoc(DOC_TESTME3), mkDoc(DOC_TESTME4)];
+        const res = evaluateQueryAST(ast, docs, { ...TEST_OPTS, defaultFields: ['title'], fieldMap: { tags: (d) => (d as any).tags } });
+        const ids = res.hits.map(h => h.id);
+        expect(ids).toContain(docs[0].id);
+        expect(ids).not.toContain(docs[1].id);
+    });
+
+    it('does not match file:"" for virtual title field (DOC_TESTME18)', () => {
+        const ast = parseQuery('file:""');
+        const docEmpty = mkDoc(DOC_TESTME18);
+        const docFull = mkDoc(DOC_TESTME15);
+        const opts = { ...TEST_OPTS, defaultFields: ['title'], fieldMap: { file: (d) => d.title } } satisfies EvaluateOptions;
+        const res = evaluateQueryAST(ast, [docEmpty, docFull], opts);
+        const ids = res.hits.map(h => h.id);
+        expect(ids).not.toContain(docEmpty.id);
+        expect(ids).not.toContain(docFull.id);
+    });
+
+    it('meta: matches notes with the field present (DOC_TESTME19, DOC_TESTME20)', () => {
+        const docs = [mkDoc(DOC_TESTME19), mkDoc(DOC_TESTME20), mkDoc(DOC_TESTME1)];
+        const res = evaluateQueryAST(parseQuery('meta:'), docs, TEST_OPTS);
+        const ids = res.hits.map(h => h.id);
+        expect(ids).toContain(docs[0].id);
+        expect(ids).toContain(docs[1].id);
+        expect(ids).not.toContain(docs[2].id);
+    });
+
+    it('meta:"" matches only empty values (DOC_TESTME20)', () => {
+        const docs = [mkDoc(DOC_TESTME19), mkDoc(DOC_TESTME20)];
+        const res = evaluateQueryAST(parseQuery('meta:""'), docs, TEST_OPTS);
+        const ids = res.hits.map(h => h.id);
+        expect(ids).toContain(docs[1].id);
+        expect(ids).not.toContain(docs[0].id);
+    });
+
+    it('meta:any matches only non-empty values (DOC_TESTME19)', () => {
+        const docs = [mkDoc(DOC_TESTME19), mkDoc(DOC_TESTME20)];
+        const res = evaluateQueryAST(parseQuery('meta:any'), docs, TEST_OPTS);
+        const ids = res.hits.map(h => h.id);
+        expect(ids).toContain(docs[0].id);
+        expect(ids).not.toContain(docs[1].id);
+    });
+
+    describe('aliases and locations presence fallback', () => {
+        it('aliases: matches notes with aliases key even when empty', () => {
+            const docs = [mkDoc(DOC_TESTME25), mkDoc(DOC_TESTME1)];
+            const res = evaluateQueryAST(parseQuery('aliases:'), docs, TEST_OPTS);
+            const ids = res.hits.map(h => h.id);
+            expect(ids).toContain(docs[0].id);
+            expect(ids).not.toContain(docs[1].id);
+        });
+
+        it('aliases:"" filters to explicit empty aliases', () => {
+            const docs = [mkDoc(DOC_TESTME25), mkDoc(DOC_TESTME26)];
+            const res = evaluateQueryAST(parseQuery('aliases:""'), docs, TEST_OPTS);
+            const ids = res.hits.map(h => h.id);
+            expect(ids).toContain(docs[0].id);
+            expect(ids).not.toContain(docs[1].id);
+        });
+
+        it('aliases:any still requires non-empty aliases', () => {
+            const docs = [mkDoc(DOC_TESTME25), mkDoc(DOC_TESTME26)];
+            const res = evaluateQueryAST(parseQuery('aliases:any'), docs, TEST_OPTS);
+            const ids = res.hits.map(h => h.id);
+            expect(ids).toContain(docs[1].id);
+            expect(ids).not.toContain(docs[0].id);
+        });
+
+        it('locations: respects frontmatter presence when empty', () => {
+            const docs = [mkDoc(DOC_TESTME27), mkDoc(DOC_TESTME1)];
+            const res = evaluateQueryAST(parseQuery('locations:'), docs, TEST_OPTS);
+            const ids = res.hits.map(h => h.id);
+            expect(ids).toContain(docs[0].id);
+            expect(ids).not.toContain(docs[1].id);
+        });
+
+        it('locations:any requires at least one location', () => {
+            const docs = [mkDoc(DOC_TESTME27), mkDoc(DOC_TESTME28)];
+            const res = evaluateQueryAST(parseQuery('locations:any'), docs, TEST_OPTS);
+            const ids = res.hits.map(h => h.id);
+            expect(ids).toContain(docs[1].id);
+            expect(ids).not.toContain(docs[0].id);
+        });
+    });
+
+});

--- a/src/utils/search/__tests__/lexer.spec.ts
+++ b/src/utils/search/__tests__/lexer.spec.ts
@@ -1,0 +1,46 @@
+import { tokenize } from '../lexer';
+
+function KVs(toks: any[]) {
+  return toks.map((t: any) => ({ kind: t.kind, value: t.value }));
+}
+
+describe('lexer', () => {
+  it('quotes take precedence over whitespace', () => {
+    // quotes take precedence over whitespace splitting
+    const toks = tokenize('abc "def"g" "hi jk"');
+    expect(KVs(toks)).toEqual([
+      { kind: 'TERM', value: 'abc' },
+      { kind: 'PHRASE', value: 'def' },
+      { kind: 'TERM', value: 'g' },
+      { kind: 'PHRASE', value: ' ' },
+      { kind: 'TERM', value: 'hi' },
+      { kind: 'TERM', value: 'jk"' },
+    ]);
+  });
+
+  it('fielded quoted value after colon', () => {
+    const toks = tokenize('key:"abc def"');
+    expect(KVs(toks)).toEqual([
+      { kind: 'TERM', value: 'key' },
+      // depending on your lexer, this may be COLON+PHRASE or synthetic TERM in parser; here we assert lexer-level:
+      // COLON token should exist:
+      { kind: 'COLON', value: undefined },
+      { kind: 'PHRASE', value: 'abc def' },
+    ]);
+  });
+
+  it('leading colon and :term are literal terms', () => {
+    expect(KVs(tokenize(':'))).toEqual([
+      { kind: 'TERM', value: ':' }]);
+    expect(KVs(tokenize(':test'))).toEqual([
+      { kind: 'TERM', value: ':test' }]);
+  });
+
+  it('colon right after closing quote is literal term start', () => {
+    const toks = tokenize('"term":test');
+    expect(KVs(toks)).toEqual([
+      { kind: 'PHRASE', value: 'term' },
+      { kind: 'TERM', value: ':test' }, // not a field separator
+    ]);
+  });
+});

--- a/src/utils/search/__tests__/parser.spec.ts
+++ b/src/utils/search/__tests__/parser.spec.ts
@@ -1,0 +1,83 @@
+import { parseQuery } from '../parser';
+
+function terms(ast: any) {
+    if (ast.type === 'And') return ast.children;
+    if (ast.type === 'Term' || ast.type === 'FieldGroup') return [ast];
+    return [];
+}
+
+describe('parse', () => {
+    it('marks phrases as phrase=true', () => {
+        const ast = parseQuery('abc "def"');
+        const ts = terms(ast);
+        expect(ts[0]).toMatchObject({ value: 'abc', phrase: false });
+        expect(ts[1]).toMatchObject({ value: 'def', phrase: true });
+    });
+
+    it('fielded quoted values stay intact', () => {
+        const ast = parseQuery('key:"abc def"');
+        const t = terms(ast)[0];
+        expect(t).toMatchObject({
+            field: 'key',
+            value: 'abc def',
+            phrase: true,
+        });
+    });
+
+    it('treats :test as literal term (no field)', () => {
+        const ast = parseQuery(':test');
+        const t = terms(ast)[0];
+        expect(t).toMatchObject({
+            field: undefined,
+            value: ':test',
+            phrase: false,
+        });
+    });
+
+    it('colon after closing quote does not open field', () => {
+        const ast = parseQuery('"term":test');
+        const ts = terms(ast);
+        expect(ts.length).toBe(2);
+        expect(ts[0]).toMatchObject({ field: undefined, value: 'term', phrase: true });
+        expect(ts[1]).toMatchObject({ field: undefined, value: ':test', phrase: false });
+    });
+
+    it('parses bookmarked:any neutrally', () => {
+        const t = terms(parseQuery('bookmarked:any'))[0];
+        expect(t).toMatchObject({ field: 'bookmarked', value: 'any', phrase: false });
+    });
+
+    it('strips leading hash in explicit tag field', () => {
+        const t = terms(parseQuery('tag:#work'))[0];
+        expect(t).toMatchObject({ field: 'tag', value: 'work', phrase: false });
+    });
+
+    it('parses field-scoped groups', () => {
+        const ast = parseQuery('tag:(foo OR bar)');
+        const node = terms(ast)[0];
+        expect(node.type).toBe('FieldGroup');
+        expect(node.field).toBe('tag');
+        expect(node.child?.type).toBe('Or');
+        const childTerms = (node.child as any).children.filter((c: any) => c.type === 'Term');
+        expect(childTerms.map((c: any) => ({ field: c.field, value: c.value }))).toEqual([
+            { field: undefined, value: 'foo' },
+            { field: undefined, value: 'bar' },
+        ]);
+    });
+
+    it('parses standalone regex with flags', () => {
+        const t = terms(parseQuery('/foo+/gi'))[0];
+        expect(t).toMatchObject({
+            field: undefined,
+            regex: { pattern: 'foo+', flags: 'gi', raw: '/foo+/gi' },
+        });
+    });
+
+    it('parses fielded regex', () => {
+        const t = terms(parseQuery('tag:/ba(r|z)/'))[0];
+        expect(t).toMatchObject({
+            field: 'tag',
+            regex: { pattern: 'ba(r|z)', flags: '', raw: '/ba(r|z)/' },
+        });
+    });
+});

--- a/src/utils/search/__tests__/validator.spec.ts
+++ b/src/utils/search/__tests__/validator.spec.ts
@@ -1,0 +1,30 @@
+import { validateQuerySyntax } from '../validator';
+
+describe('validate (structural only)', () => {
+    it('balanced parentheses', () => {
+        expect(validateQuerySyntax('(a AND b)')).toEqual({ ok: true });
+        expect(validateQuerySyntax('(a AND b')).toMatchObject({ ok: false, issue: { code: 'UNBALANCED_PARENS' } });
+    });
+
+    it('AND/OR placement', () => {
+        expect(validateQuerySyntax('a AND b')).toEqual({ ok: true });
+        expect(validateQuerySyntax('AND b')).toMatchObject({ ok: false, issue: { code: 'DANGLING_OPERATOR' } });
+        expect(validateQuerySyntax('a OR')).toMatchObject({ ok: false, issue: { code: 'DANGLING_OPERATOR' } });
+        expect(validateQuerySyntax('OR')).toMatchObject({ ok: false, issue: { code: 'DANGLING_OPERATOR' } });
+    });
+
+    it('unfinished regex', () => {
+        expect(validateQuerySyntax('/re.*/i')).toEqual({ ok: true });
+        expect(validateQuerySyntax('/re.*')).toMatchObject({ ok: false, issue: { code: 'UNFINISHED_REGEX' } });
+    });
+
+    it('quotes do not error (validator is lenient)', () => {
+        expect(validateQuerySyntax('"abc" AND def')).toEqual({ ok: true });
+        expect(validateQuerySyntax('"abc')).toEqual({ ok: true }); // validator doesn’t enforce quotes
+    });
+
+    it('treats AND/OR inside field values as literals', () => {
+        expect(validateQuerySyntax('status:AND')).toEqual({ ok: true });
+        expect(validateQuerySyntax('tag:orphan')).toEqual({ ok: true });
+    });
+});

--- a/src/utils/search/evaluator.ts
+++ b/src/utils/search/evaluator.ts
@@ -1,0 +1,596 @@
+import Fuse from 'fuse.js';
+import { ASTNode, TermNode, FieldGroupNode } from './parser';
+import { dbgEval, j } from '../../api/logger/debugger';
+import { dumpTargetNoteDebug } from '../../api/logger/targetNoteDebugger';
+import { parsedYAMLFrontmatter } from '../yaml';
+
+/**
+ * Document shape used by the evaluator. Extend to your needs.
+ */
+export type Doc = {
+  id: string;                 // unique id (e.g., path)
+  title?: string;
+  path?: string;
+  tags?: string[];
+  content?: string;              // note body/content (for content: special case)
+  // You can add more fields and map them via EvaluateOptions.fieldMap
+} & Record<string, unknown>; // For testing, allow arbitrary extra fields
+
+export type EvaluateOptions = {
+  // Which fields to search when a term is unfielded
+  defaultFields: string[]; // e.g., ['title','tags','path']
+
+  // Map external field names to getters on the doc
+  // Example: { tag: (d) => d.tags ?? [], title: (d) => d.title ?? '' }
+  fieldMap?: Record<string, (doc: Doc) => string | string[] | undefined>;
+
+  // Fuzzy config (Fuse.js)
+  fuzzy?: {
+    threshold?: number;          // default 0.35
+    minMatchCharLength?: number; // default 2
+  };
+};
+
+export type SearchHit = {
+  id: string;
+  score: number; // lower is better
+};
+
+export type SearchResult = {
+  hits: SearchHit[]; // sorted by score asc
+  // For debugging / UI
+  diagnostics?: { ast?: string };
+};
+
+const VIRTUAL_FIELDS = new Set([
+  'title', // never empty
+  'file', // alias for title
+  'path', // never empty
+  'created', // never empty
+  'modified', // never empty
+  'tag', // inline + YAML tags, exact match only
+  'tags', // shorthand for 'tag:/.../i'
+  'content', // can be empty
+  'bookmarked', // special boolean handling
+  'anyname', // title + aliases
+  'full', // content + path
+  'aliases', // frontmatter, preserve empty-but-present distinction
+  'locations', // frontmatter, preserve empty-but-present distinction
+]);
+
+// ————————————————————————————————————————————————————————————
+// Virtual fields and empty-but-present distinction
+// ————————————————————————————————————————————————————————————
+//
+// Certain virtual arrays (FRONTMATTER_PRESENCE_FIELDS) normalised during load still need to honour frontmatter-defined-but-empty values.
+
+const FRONTMATTER_PRESENCE_FIELDS = new Set(['aliases', 'locations']);
+
+function fieldAllowsEmptyPresence(field: string | undefined): boolean {
+  return field ? FRONTMATTER_PRESENCE_FIELDS.has(field) : false;
+}
+
+function frontmatterPresenceFallback(field: string | undefined, doc: Doc, values: string[]): boolean {
+  if (!fieldAllowsEmptyPresence(field)) {
+    return values.length > 0;
+  }
+  if (values.length > 0) {
+    return true;
+  }
+  const frontmatter = parsedYAMLFrontmatter(String((doc as any).content ?? ''));
+  return Boolean(frontmatter && field && Object.prototype.hasOwnProperty.call(frontmatter, field));
+}
+
+function isFieldPresent(field: string | undefined, doc: Doc, values: string[]): boolean {
+  if (!field) return false;
+  if (fieldAllowsEmptyPresence(field)) {
+    return frontmatterPresenceFallback(field, doc, values);
+  }
+  const docAny = doc as any;
+  return values.length > 0 || Object.prototype.hasOwnProperty.call(docAny, field) || field in docAny;
+}
+
+// ————————————————————————————————————————————————————————————
+// Utilities
+// ————————————————————————————————————————————————————————————
+
+function fold(s: string): string {
+  return s
+    .normalize('NFD')
+    // remove diacritics
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase();
+}
+
+function strIncludes(haystack: string, needle: string): boolean {
+  return fold(haystack).includes(fold(needle));
+}
+
+function strEqualsCaseFold(a: string, b: string): boolean {
+  return fold(a) === fold(b);
+}
+
+function isEmptyStringValue(v: string): boolean {
+  return v.trim().length === 0;
+}
+
+function hasNonEmptyValue(values: string[]): boolean {
+  return values.some(v => !isEmptyStringValue(v));
+}
+
+// Unescape backslash-escaped quotes and backslashes in query literals (phrases only)
+function unescapeQueryLiteral(s: string): string {
+  // \" -> ", \\ -> \
+  return s.replace(/\\([\\"])/g, '$1');
+}
+
+function valueToStrings(v: unknown): string[] {
+  if (v == null) return [];
+  if (Array.isArray(v)) return v.flatMap(valueToStrings);
+  if (typeof v === 'string') return [v];
+  if (typeof v === 'number' || typeof v === 'boolean') return [String(v)];
+  // objects: join shallow string values
+  return [];
+}
+
+export function getFieldValues(doc: Doc, field: string, opts: EvaluateOptions): string[] {
+  const TARGET = "name-of-your-note"; // for targeted debugging
+  const isTarget = String((doc as any).id || "").includes(TARGET);
+
+  // Special case: content: → none-empty notes only
+  if (field.toLowerCase() === 'content') {
+    const out = valueToStrings(doc.content).map(s => s.trim()).filter(s => s.length > 0);
+    if (isTarget) dbgEval('getFieldValues, TARGET content,', { out });
+    return out;
+  }
+
+  const getter = opts.fieldMap?.[field];
+  if (getter) return valueToStrings(getter(doc));
+  // fallback to direct properties
+  const val = (doc as any)[field];
+  const out = valueToStrings(val);
+  if (isTarget && (field === "title" || field === "tags" || field === "path")) {
+    dbgEval("getFieldValues, TARGET,", { field, out });
+  }
+  return out;
+}
+
+function collectFields(
+  doc: Doc,
+  fields: string[],
+  opts: EvaluateOptions,
+  entryOverride?: EntryOverride
+): string[] {
+  const out: string[] = [];
+  for (const f of fields) {
+    if (
+      entryOverride &&
+      doc.id === entryOverride.docId &&
+      f.toLowerCase() === entryOverride.fieldLower
+    ) {
+      out.push(...entryOverride.values);
+    } else {
+      out.push(...getFieldValues(doc, f, opts));
+    }
+  }
+  return out;
+}
+
+// ————————————————————————————————————————————————————————————
+// Leaf evaluation
+// ————————————————————————————————————————————————————————————
+
+type LeafEval = {
+  ids: Set<string>;
+  scores: Map<string, number>; // only populated for fuzzy
+};
+
+type EntryOverride = {
+  docId: string;
+  field: string;
+  fieldLower: string;
+  values: string[];
+};
+
+function evalExactLeaf(
+  docs: Doc[],
+  node: TermNode,
+  fields: string[],
+  opts: EvaluateOptions,
+  primaryField?: string,
+  forcePresenceNonEmpty = false,
+  entryOverride?: EntryOverride
+): LeafEval {
+  let matched;
+  const q = node.phrase ? unescapeQueryLiteral(node.value) : node.value;
+  const ids = new Set<string>();
+  for (const d of docs) {
+    const values = collectFields(d, fields, opts, entryOverride);
+    const targetField = primaryField;
+    const docAny = d as any;
+
+    const propertyPresent = isFieldPresent(targetField, d, values);
+
+    const hasValues = values.length > 0 || propertyPresent;
+    const hasNonEmpty = hasNonEmptyValue(values);
+    // Bare key:   ⇒ present AND non-empty (handled via forcePresenceNonEmpty for virtual fields)
+    // key:""      ⇒ handled earlier (empty-only)
+    const valLower = node.value.toLowerCase();
+    if (targetField === 'bookmarked') {
+      const isTrue = values.some(v => strEqualsCaseFold(v, 'true'));
+      if (node.phrase) {
+        if (node.value === '') {
+          matched = false;
+        } else if (valLower === 'true') {
+          matched = isTrue;
+        } else if (valLower === 'false') {
+          // Treat quoted "false" the same as unquoted false: never matches
+          matched = false;
+        } else {
+          matched = values.some(v => strEqualsCaseFold(v, node.value));
+        }
+      } else {
+        if (node.value === '' || valLower === 'any' || valLower === 'true') {
+          matched = isTrue;
+        } else if (valLower === 'false') {
+          matched = false;
+        } else {
+          matched = values.some(v => strEqualsCaseFold(v, node.value));
+        }
+      }
+    } else if (targetField && !node.phrase) {
+      if (node.value === '') {
+        matched = forcePresenceNonEmpty ? hasNonEmpty : hasValues;
+      } else if (valLower === 'any') {
+        matched = hasNonEmpty;
+      } else {
+        matched = values.some(v => strIncludes(v, node.value));
+      }
+    } else {
+      matched = values.some(v => strIncludes(v, q));
+    }
+    if (matched) ids.add(d.id);
+  }
+
+  // For targeted debugging
+  const targetNoteTitle = "testme7";
+  dumpTargetNoteDebug(targetNoteTitle, docs, fields, node, opts, Boolean(matched));
+
+  return { ids, scores: new Map() };
+}
+
+function buildFuseIndex(
+  docs: Doc[],
+  fields: string[],
+  opts: EvaluateOptions,
+  entryOverride?: EntryOverride
+) {
+  // Build a single index over the desired fields, mapping them onto a joined string per doc for simplicity.
+  // For better weighting, you could use Fuse keys per field; here we keep it lightweight.
+  const items = docs.map(d => ({
+    id: d.id,
+    blob: collectFields(d, fields, opts, entryOverride).join(' \n '),
+  }));
+  return new Fuse(items, {
+    includeScore: true,
+    threshold: opts.fuzzy?.threshold ?? 0.35,
+    minMatchCharLength: opts.fuzzy?.minMatchCharLength ?? 2,
+    ignoreLocation: true,
+    keys: ['blob'],
+  });
+}
+
+function evalRegexLeaf(
+  docs: Doc[],
+  node: TermNode,
+  fields: string[],
+  opts: EvaluateOptions,
+  entryOverride?: EntryOverride
+): LeafEval {
+  // 1. Log at function start
+  dbgEval('evalRegexLeaf, start', { pattern: node.regex?.pattern, flags: node.regex?.flags, docCount: docs.length });
+  const ids = new Set<string>();
+  const scores = new Map<string, number>();
+
+  // Defensive: node.regex should exist here
+  if (!node.regex) return { ids, scores };
+
+  let re: RegExp;
+  try {
+    re = new RegExp(node.regex.pattern, node.regex.flags);
+    // 2. Log compiled regex
+    dbgEval('evalRegexLeaf, compiled regex', re);
+  } catch {
+    // Invalid regex → no matches (you could also choose to fallback to literal)
+    return { ids, scores };
+  }
+
+  for (const d of docs) {
+    const values = collectFields(d, fields, opts, entryOverride);
+    const matched = values.some(v => re.test(v));
+    if (matched) {
+      dbgEval('evalRegexLeaf, MATCH', { id: d.id, testedValues: values.length });
+      ids.add(d.id);
+    }
+  }
+  // 6. Log total matches before returning
+  dbgEval('evalRegexLeaf, done', { matchCount: ids.size });
+  return { ids, scores };
+}
+
+function evalFuzzyLeaf(
+  docs: Doc[],
+  node: TermNode,
+  fields: string[],
+  opts: EvaluateOptions,
+  fuseCache: Map<string, Fuse<any>>,
+  entryOverride?: EntryOverride,
+  allowCache = true
+): LeafEval {
+  let fuse: Fuse<any>;
+  if (allowCache && !entryOverride) {
+    const cacheKey = fields.join('|');
+    let cached = fuseCache.get(cacheKey);
+    if (!cached) {
+      cached = buildFuseIndex(docs, fields, opts);
+      fuseCache.set(cacheKey, cached);
+    }
+    fuse = cached;
+  } else {
+    fuse = buildFuseIndex(docs, fields, opts, entryOverride);
+  }
+  const q = node.phrase ? unescapeQueryLiteral(node.value) : node.value;
+  const results = fuse.search(q);
+  const ids = new Set<string>();
+  const scores = new Map<string, number>();
+  for (const r of results) {
+    ids.add(r.item.id);
+    // Fuse score: 0 perfect → 1 worse. Keep as-is for additive ranking.
+    scores.set(r.item.id, Math.max(0, r.score ?? 0));
+  }
+  return { ids, scores };
+}
+
+// ————————————————————————————————————————————————————————————
+// Boolean combination helpers
+// ————————————————————————————————————————————————————————————
+
+function setIntersection(a: Set<string>, b: Set<string>): Set<string> {
+  if (a.size > b.size) [a, b] = [b, a];
+  const out = new Set<string>();
+  for (const x of a) if (b.has(x)) out.add(x);
+  return out;
+}
+
+function setUnion(a: Set<string>, b: Set<string>): Set<string> {
+  const out = new Set<string>(a);
+  for (const x of b) out.add(x);
+  return out;
+}
+
+function combineScores(sum: Map<string, number>, add: Map<string, number>) {
+  for (const [id, s] of add) sum.set(id, (sum.get(id) ?? 0) + s);
+}
+
+// ————————————————————————————————————————————————————————————
+// Evaluator
+// ————————————————————————————————————————————————————————————
+
+export function evaluateQueryAST(ast: ASTNode, docs: Doc[], opts: EvaluateOptions): SearchResult {
+  dbgEval('evaluateQueryAST, AST input:', j(ast));
+  const defaultFields = opts.defaultFields;
+  const fuseCache = new Map<string, Fuse<any>>();
+  function evalNode(
+    node: ASTNode,
+    overrideField?: string,
+    docsForEval: Doc[] = docs,
+    entryOverride?: EntryOverride,
+    allowCache = !entryOverride && docsForEval === docs
+  ): { ids: Set<string>, scores: Map<string, number> } {
+    switch (node.type) {
+      case 'Term': {
+        const fields = node.field ? [node.field] : overrideField ? [overrideField] : defaultFields;
+        const effectiveField = (node.field ?? overrideField)?.toLowerCase();
+        const isVirtualField = effectiveField ? VIRTUAL_FIELDS.has(effectiveField) : false;
+
+        if (
+          isVirtualField &&
+          effectiveField !== 'bookmarked' &&
+          !fieldAllowsEmptyPresence(effectiveField) &&
+          node.phrase &&
+          node.value === ''
+        ) {
+          return { ids: new Set(), scores: new Map() };
+        }
+
+        // Empty-quote semantics: "" means "empty or undefined" for the field(s)
+        if (node.phrase && node.value === '') {
+          if (node.field) {
+            const ids = new Set<string>();
+            const SAMPLE_LIMIT = 5;
+            const sampleMatched: any[] = [];
+            const sampleMissed: any[] = [];
+            let matchedCount = 0;
+
+            for (const d of docsForEval) {
+              const values = collectFields(d, fields, opts, entryOverride);
+              const docAny = d as any;
+              const propertyPresent = isFieldPresent(node.field, d, values);
+              const present = values.length > 0 || propertyPresent;
+              const isEmptyOrUndefined = values.length === 0 || values.every(isEmptyStringValue);
+              const matched = present && isEmptyOrUndefined;
+              if (matched) {
+                ids.add(d.id);
+                matchedCount++;
+                if (sampleMatched.length < SAMPLE_LIMIT) {
+                  sampleMatched.push({ id: d.id, raw: values });
+                }
+              } else if (sampleMissed.length < SAMPLE_LIMIT) {
+                sampleMissed.push({ id: d.id, raw: values });
+              }
+            }
+
+            dbgEval('empty-quote fielded, summary', {
+              field: node.field,
+              totalDocs: docsForEval.length,
+              matchedCount,
+              sampleMatched,
+              sampleMissed,
+            });
+
+            return { ids, scores: new Map() };
+          } else {
+            const ids = new Set<string>();
+            // Unfielded "": match docs where ANY default field is present AND empty
+            for (const d of docsForEval) {
+              for (const f of fields) {
+                const valuesForField = collectFields(d, [f], opts, entryOverride);
+                const docAny = d as any;
+                const propertyPresent = (f in docAny) || Object.prototype.hasOwnProperty.call(docAny, f);
+                const present = valuesForField.length > 0 || propertyPresent;
+                const isEmptyOrUndefined = valuesForField.length === 0 || valuesForField.every(isEmptyStringValue);
+                if (present && isEmptyOrUndefined) { ids.add(d.id); break; }
+              }
+            }
+            return { ids, scores: new Map() };
+          }
+        }
+
+        // Regex has highest priority
+        if (node.regex) {
+          return evalRegexLeaf(docsForEval, node, fields, opts, entryOverride);
+        }
+
+        // Fuzzy next (only for terms explicitly suffixed with ~)
+        if (node.fuzzy) {
+          return evalFuzzyLeaf(docsForEval, node, fields, opts, fuseCache, entryOverride, allowCache);
+        }
+
+        // Otherwise: exact (folded includes)
+        const exactMatchField = effectiveField;
+        if (exactMatchField === 'tag') {
+          const target = node.value.startsWith('#') ? node.value.slice(1) : node.value;
+          const ids = new Set<string>();
+          for (const d of docsForEval) {
+            const tagValues = collectFields(d, fields, opts, entryOverride).map(v => (typeof v === 'string' && v.startsWith('#') ? v.slice(1) : v));
+            if (tagValues.some(v => strEqualsCaseFold(v, target))) {
+              ids.add(d.id);
+            }
+          }
+          return { ids, scores: new Map() };
+        }
+
+        if (exactMatchField === 'tags') {
+          const target = node.value;
+          const ids = new Set<string>();
+          for (const d of docsForEval) {
+            const tagValues = collectFields(d, fields, opts, entryOverride);
+            if (tagValues.some(v => strIncludes(v, target))) {
+              ids.add(d.id);
+            }
+          }
+          return { ids, scores: new Map() };
+        }
+
+        const primaryField = node.field ?? overrideField;
+        const forcePresenceNonEmpty = Boolean(
+          primaryField &&
+          isVirtualField &&
+          !fieldAllowsEmptyPresence(effectiveField)
+        );
+        return evalExactLeaf(
+          docsForEval,
+          node,
+          fields,
+          opts,
+          primaryField,
+          forcePresenceNonEmpty,
+          entryOverride
+        );
+      }
+      case 'Not': {
+        const inner = evalNode(node.child, overrideField, docsForEval, entryOverride, allowCache);
+        const ids = new Set<string>();
+        for (const d of docsForEval) {
+          if (!inner.ids.has(d.id)) ids.add(d.id);
+        }
+        return { ids, scores: new Map() };
+      }
+      case 'And': {
+        let acc: Set<string> | null = null;
+        const scoreAcc = new Map<string, number>();
+        for (const c of node.children) {
+          const { ids, scores } = evalNode(c, overrideField, docsForEval, entryOverride, allowCache);
+          acc = acc ? setIntersection(acc, ids) : ids;
+          combineScores(scoreAcc, scores);
+          if (acc.size === 0) break;
+        }
+        return { ids: acc ?? new Set(), scores: scoreAcc };
+      }
+      case 'Or': {
+        let acc = new Set<string>();
+        const scoreAcc = new Map<string, number>();
+        for (const c of node.children) {
+          const { ids, scores } = evalNode(c, overrideField, docsForEval, entryOverride, allowCache);
+          acc = setUnion(acc, ids);
+          combineScores(scoreAcc, scores);
+        }
+        return { ids: acc, scores: scoreAcc };
+      }
+      case 'Group': {
+        return node.child
+          ? evalNode(node.child, overrideField, docsForEval, entryOverride, allowCache)
+          : { ids: new Set(), scores: new Map() };
+      }
+      case 'FieldGroup': {
+        if (!node.child) {
+          return { ids: new Set(), scores: new Map() };
+        }
+        const ids = new Set<string>();
+        const scoreAcc = new Map<string, number>();
+        const fieldName = node.field;
+        const fieldLower = fieldName.toLowerCase();
+
+        for (const d of docsForEval) {
+          const entryValues = getFieldValues(d, fieldName, opts);
+          if (entryValues.length === 0) continue;
+
+          for (const value of entryValues) {
+            const override: EntryOverride = {
+              docId: d.id,
+              field: fieldName,
+              fieldLower,
+              values: [value],
+            };
+
+            const { ids: childIds, scores } = evalNode(
+              node.child,
+              fieldName,
+              [d],
+              override,
+              false
+            );
+
+            if (childIds.has(d.id)) {
+              ids.add(d.id);
+              combineScores(scoreAcc, scores);
+              break;
+            }
+          }
+        }
+
+        return { ids, scores: scoreAcc };
+      }
+    }
+  }
+
+  const { ids, scores } = evalNode(ast, undefined, docs, undefined, true);
+  // Convert to sorted list: lower score first; exact-only docs have score 0
+  const hits: SearchHit[] = Array.from(ids).map(id => ({ id, score: scores.get(id) ?? 0 }));
+  hits.sort((a, b) => a.score - b.score || a.id.localeCompare(b.id));
+
+  return { hits };
+}
+
+// Convenience: run string query directly if caller prefers
+export { parseQuery } from './parser';

--- a/src/utils/search/lexer.ts
+++ b/src/utils/search/lexer.ts
@@ -1,0 +1,158 @@
+// src/utils/search/lexer.ts
+import { dbgLexer } from '../../api/logger/debugger';
+import { Position, RegexInfo, Token } from './types';
+
+export function noMatchRegex(): RegexInfo {
+  return { pattern: '(?!)', flags: '', raw: '/(?!)/' };
+}
+
+export function isWhitespace(ch: string) { return /\s/.test(ch); }
+export function isPunct(ch: string) { return /[():~]/.test(ch); }
+
+function isBoundary(prev: string | undefined) {
+  return prev === undefined || isWhitespace(prev) || isPunct(prev) || prev === '"';
+}
+
+function readQuoted(input: string, startIndex: number) {
+  // Expects input[startIndex] === '"'. Returns { end, value } if closed; null otherwise.
+  let j = startIndex + 1;
+  const n = input.length;
+  let buf = '';
+  let escaped = false;
+  while (j < n) {
+    const c = input[j++];
+    if (escaped) { buf += c; escaped = false; continue; }
+    if (c === '\\') { escaped = true; continue; }
+    if (c === '"') { return { end: j, value: buf }; }
+    buf += c;
+  }
+  return null; // no closing quote
+}
+
+export function readRegex(input: string, startIndex: number) {
+  // expects input[startIndex] === '/'
+  let i = startIndex + 1;
+  const n = input.length;
+  let escaped = false;
+
+  while (i < n) {
+    const c = input[i++];
+    if (!escaped && c === '/') {
+      // found terminating '/'
+      const bodyEnd = i - 1; // char before the slash
+      // collect flags
+      let flags = '';
+      // When reading regex flags, stop only at whitespace
+      while (i < n && !isWhitespace(input[i])) flags += input[i++];
+      const raw = input.slice(startIndex, i);
+
+      // Validate that regex flags contain only allowed JavaScript flags
+      const validFlags = 'gimsyu';
+      if ([...flags].some(f => !validFlags.includes(f))) {
+        // Produce a REGEX token that will match nothing
+        return { end: i, token: noMatchRegex() };
+      }
+
+      const pattern = input.slice(startIndex + 1, bodyEnd);
+      return { end: i, token: { pattern, flags, raw } };
+    }
+    escaped = !escaped && c === '\\';
+  }
+  // no closing slash → not a regex
+  return null;
+}
+
+export function tokenize(input: string): Token[] {
+  const toks: Token[] = [];
+  let i = 0;
+  const n = input.length;
+  const push = (t: Token) => toks.push(t);
+
+  while (i < n) {
+    const start = i;
+    const ch = input[i];
+
+    // Regex literal: /pattern/flags  (JS-flavored)
+    if (ch === '/') {
+      const rr = readRegex(input, i);
+      if (rr) {
+        i = rr.end;
+        push({ kind: 'REGEX', pattern: rr.token.pattern, flags: rr.token.flags, raw: rr.token.raw, pos: { start, end: i } });
+        continue;
+      }
+      // fall through if not a valid /regex/
+    }
+
+    if (ch === '"') {
+      const q = readQuoted(input, i);
+      if (q) {
+        push({ kind: 'PHRASE', value: q.value, pos: { start, end: q.end } });
+        i = q.end;
+        continue;
+      }
+      // no closing quote → fall through to TERM logic
+    }
+
+    if (ch === '(') { i++; push({ kind: 'LPAREN', pos: { start, end: i } }); continue; }
+    if (ch === ')') { i++; push({ kind: 'RPAREN', pos: { start, end: i } }); continue; }
+    if (ch === '-') { i++; push({ kind: 'MINUS', pos: { start, end: i } }); continue; }
+    if (ch === ':') {
+      const prev = i > 0 ? input[i - 1] : undefined;
+      const atBoundary = isBoundary(prev);
+
+      if (atBoundary) {
+        // Treat leading ':' or a ':' immediately after a closing quote as a literal term start
+        let buf = ':';
+        i++;
+        while (i < n) {
+          const c = input[i];
+          if (isWhitespace(c) || isPunct(c)) break;
+          buf += c; i++;
+        }
+        push({ kind: 'TERM', value: buf, pos: { start, end: i } });
+        continue;
+      } else {
+        i++;
+        push({ kind: 'COLON', pos: { start, end: i } });
+        continue;
+      }
+    }
+    if (ch === '~') { i++; push({ kind: 'TILDE', pos: { start, end: i } }); continue; }
+
+    if (isWhitespace(ch)) {
+      while (i < n && isWhitespace(input[i])) i++;
+      push({ kind: 'WS', pos: { start, end: i } });
+      continue;
+    }
+
+    // Bare term: read until whitespace or punctuation we treat as separator.
+    // If we encounter '"' and it begins a valid phrase, stop so the phrase handler can consume it.
+    let buf = '';
+    while (i < n) {
+      const c = input[i];
+      if (isWhitespace(c) || isPunct(c)) break;
+
+      if (c === '"') {
+        const q = readQuoted(input, i);
+        if (q) break; // let phrase branch handle it next
+        // else treat '"' as literal within the term
+      }
+
+      buf += c; i++;
+    }
+    push({ kind: 'TERM', value: buf, pos: { start, end: i } });
+  }
+
+  // Map keywords AND/OR (case-insensitive) and drop WS for the parser convenience
+  const normalized: Token[] = [];
+  for (const t of toks) {
+    if (t.kind === 'TERM') {
+      const v = t.value.toUpperCase();
+      if (v === 'AND') { normalized.push({ kind: 'AND', pos: t.pos }); continue; }
+      if (v === 'OR') { normalized.push({ kind: 'OR', pos: t.pos }); continue; }
+    }
+    if (t.kind !== 'WS') normalized.push(t);
+  }
+  dbgLexer('tokenize normalized tokens:', normalized);
+  return normalized;
+}

--- a/src/utils/search/parser.ts
+++ b/src/utils/search/parser.ts
@@ -1,0 +1,469 @@
+import { dbgParse, j } from '../../api/logger/debugger';
+import { validateQuerySyntax } from './validator';
+
+// Move shared types & lexer helpers to dedicated modules
+import { Position, RegexInfo, Token } from './types';
+import { tokenize, readRegex, noMatchRegex } from './lexer';
+
+/*
+ * Obsidian-style search parser → AST (TypeScript)
+ * Supports:
+ *  - Terms and quoted phrases
+ *  - Fielded terms: tag:foo, path:"notes/", title:Bar
+ *  - Negation with leading '-'
+ *  - Parentheses for grouping
+ *  - Boolean operators: AND, OR (case-insensitive). Default operator is AND.
+ *  - Per-term fuzzy suffix: term~ or "phrase"~ (flag only; execution layer decides behavior)
+ *  - To use regular expressions in your search term, surround the expression with forward slashes (/).
+ */
+
+// Parser is neutral for special fields; evaluation layer handles semantics
+function normalizeSpecialField(
+  _field: string | undefined,
+  raw: string,
+  phrase: boolean
+): { raw: string; phrase: boolean } {
+  return { raw, phrase };
+}
+
+export type TermNode = {
+  type: 'Term';
+  field?: string;        // e.g., 'tag', 'path', 'title', or frontmatter key
+  value: string;         // raw value (without quotes)
+  phrase: boolean;       // true if originally quoted
+  fuzzy: boolean;        // true if token had trailing '~'
+  regex?: RegexInfo | null;
+  pos: Position;
+};
+
+export type NotNode = {
+  type: 'Not';
+  child: ASTNode;
+  pos: Position;
+};
+
+export type AndNode = {
+  type: 'And';
+  children: ASTNode[];   // flattened list (at least 2)
+  pos: Position;
+};
+
+export type OrNode = {
+  type: 'Or';
+  children: ASTNode[];   // flattened list (at least 2)
+  pos: Position;
+};
+
+export type GroupNode = {
+  type: 'Group';
+  child: ASTNode | null; // may be null if group is empty (rare/invalid)
+  pos: Position;
+};
+
+export type FieldGroupNode = {
+  type: 'FieldGroup';
+  field: string;
+  child: ASTNode | null;
+  pos: Position;
+};
+
+export type ASTNode = TermNode | NotNode | AndNode | OrNode | GroupNode | FieldGroupNode;
+
+// ————————————————————————————————————————————————————————————
+// Parser (recursive descent)
+// Precedence: NOT > AND (implicit or explicit) > OR
+// ————————————————————————————————————————————————————————————
+
+class Parser {
+  private i = 0;
+  constructor(private toks: Token[], private input: string) { }
+
+  private peek(k = 0): Token | undefined { return this.toks[this.i + k]; }
+  private eat(kind?: Token['kind']): Token | undefined {
+    const t = this.toks[this.i];
+    if (!t) return undefined;
+    if (kind && t.kind !== kind) return undefined;
+    this.i++; return t;
+  }
+
+  private findValueEnd(startPos: number): number {
+    const s = this.input;
+    let i = startPos;
+    while (i < s.length && !/\s/.test(s[i])) i++;
+    return i;
+  }
+
+  private findQuotedValueEnd(startPos: number): number | null {
+    // Expects input[startPos] === '"'; returns the index AFTER the closing quote, or null if not found
+    const s = this.input;
+    let i = startPos + 1;
+    let escaped = false;
+    while (i < s.length) {
+      const c = s[i++];
+      if (escaped) { escaped = false; continue; }
+      if (c === '\\') { escaped = true; continue; }
+      if (c === '"') { return i; }
+    }
+    return null; // no closing quote
+  }
+
+  private isAdjacent(endA: number, startB: number | undefined): boolean {
+    return typeof startB === 'number' && startB === endA;
+  }
+
+  /**
+   * Resolve field and value token for a term.
+   * - Handles bare '~' literal
+   * - Detects TERM COLON adjacency to form a field
+   * - Creates synthetic TERM for value slices (quoted-after-colon or whitespace-delimited)
+   */
+  private resolveFieldAndValue(first: Token): {
+    field?: string;
+    valueTok: Token;
+    isBareTildeLiteral: boolean;
+    startTok: Token;
+    valueIsGroup: boolean;
+    groupPosStart?: number;
+  } {
+    let field: string | undefined;
+    let valueTok: Token = first;
+    let isBareTildeLiteral = false;
+    let valueIsGroup = false;
+    let groupPosStart: number | undefined;
+    const startTok = first;
+
+    if (first.kind === 'TILDE') {
+      // Treat standalone '~' as a literal value token
+      isBareTildeLiteral = true;
+      valueTok = { kind: 'TERM', value: '~', pos: first.pos } as any;
+      return { field, valueTok, isBareTildeLiteral, startTok, valueIsGroup, groupPosStart };
+    }
+
+    if (first.kind === 'TERM' && this.peek()?.kind === 'COLON') {
+      field = (first as any).value;
+      const colonTok = this.eat('COLON')!;
+      const next = this.peek();
+      const adjacent = this.isAdjacent(colonTok.pos.end, next?.pos.start);
+
+      if (adjacent) {
+        if (next?.kind === 'LPAREN') {
+          valueIsGroup = true;
+          valueTok = next;
+          groupPosStart = colonTok.pos.end;
+          return { field, valueTok, isBareTildeLiteral, startTok, valueIsGroup, groupPosStart };
+        }
+        const valueStart = colonTok.pos.end;
+        let valueEnd: number;
+        if (this.input[valueStart] === '"') {
+          const quotedEnd = this.findQuotedValueEnd(valueStart);
+          valueEnd = quotedEnd != null ? quotedEnd : this.findValueEnd(valueStart);
+        } else {
+          valueEnd = this.findValueEnd(valueStart);
+        }
+        const rawSlice = this.input.slice(valueStart, valueEnd);
+        while (this.peek() && (this.peek() as any).pos.start < valueEnd) this.eat();
+        valueTok = { kind: 'TERM', value: rawSlice, pos: { start: valueStart, end: valueEnd } } as any;
+      } else {
+        // Empty value for this field; keep next token for subsequent term
+        valueTok = { kind: 'TERM', value: '', pos: next ? next.pos : first.pos } as any;
+      }
+    }
+
+    return { field, valueTok, isBareTildeLiteral, startTok, valueIsGroup, groupPosStart };
+  }
+
+  /**
+   * Convert a value token into raw text / phrase flag / regex info.
+   * - Preserves PHRASE tokens as phrase=true
+   * - Detects synthetically quoted TERM ("...")
+   * - Detects regex literals that span exactly the token
+   */
+  private coerceValueFromToken(valueTok: Token): { raw: string; phrase: boolean; regexInfo: RegexInfo | null } {
+    let raw = '';
+    let phrase = false;
+    let regexInfo: RegexInfo | null = null;
+
+    if (valueTok.kind === 'REGEX') {
+      raw = (valueTok as any).raw;
+      regexInfo = { pattern: (valueTok as any).pattern, flags: (valueTok as any).flags, raw: (valueTok as any).raw };
+      return { raw, phrase, regexInfo };
+    }
+
+    if (valueTok.kind === 'PHRASE') {
+      raw = (valueTok as any).value ?? '';
+      phrase = true;
+      return { raw, phrase, regexInfo };
+    }
+
+    // TERM
+    raw = (valueTok as any).value ?? '';
+    if (raw.length >= 2 && raw.startsWith('"') && raw.endsWith('"')) {
+      phrase = true;
+      raw = raw.slice(1, -1);
+      return { raw, phrase, regexInfo };
+    }
+
+    // Regex literal if TERM starts with '/' and spans token
+    if (raw.startsWith('/')) {
+      const rr = readRegex(this.input, (valueTok as any).pos.start);
+      if (rr && rr.end === (valueTok as any).pos.end) {
+        regexInfo = { pattern: rr.token.pattern, flags: rr.token.flags, raw: rr.token.raw };
+        raw = rr.token.raw;
+      }
+    }
+
+    return { raw, phrase, regexInfo };
+  }
+
+  private parseFuzzyOperator(
+    rawIn: string,
+    valueTok: Token,
+    regexInfo: RegexInfo | null,
+    isBareTildeLiteral: boolean
+  ): { raw: string; fuzzy: boolean; endPos: number } {
+    let raw = rawIn;
+    let fuzzy = false;
+    let endPos = (valueTok as any).pos?.end ?? (valueTok as any).pos?.end;
+
+    // Do not treat '~' as operator when it's a bare literal or exactly "~"
+    if (isBareTildeLiteral || raw === '~') {
+      return { raw, fuzzy, endPos };
+    }
+
+    // Case A: raw value itself ends with '~' (e.g., key:value~ or key:"phrase"~)
+    if (raw.length > 1 && raw.endsWith('~')) {
+      fuzzy = true;
+      raw = raw.slice(0, -1);
+      return { raw, fuzzy, endPos };
+    }
+
+    // Case B: adjacent standalone '~' token (e.g., value~ or "phrase"~)
+    const nextTok = this.peek();
+    if (
+      !regexInfo &&
+      raw.length > 0 &&
+      nextTok?.kind === 'TILDE' &&
+      nextTok.pos.start === (valueTok as any).pos.end
+    ) {
+      this.eat('TILDE');
+      fuzzy = true;
+      endPos = nextTok.pos.end;
+    }
+
+    return { raw, fuzzy, endPos };
+  }
+
+  parse(): ASTNode | GroupNode {
+    const node = this.parseOr();
+    dbgParse('parse, final AST:', j(node));
+    // If multiple top-level nodes without OR, we already handled as AND inside parseAnd
+    return node;
+  }
+
+  private parseOr(): ASTNode {
+    let left = this.parseAnd();
+    while (this.peek()?.kind === 'OR') {
+      const start = (left as any).pos.start;
+      this.eat('OR');
+      const right = this.parseAnd();
+      const pos: Position = { start, end: (right as any).pos.end };
+      if (left.type === 'Or') {
+        left = { type: 'Or', children: [...left.children, right], pos };
+      } else {
+        left = { type: 'Or', children: [left, right], pos };
+      }
+    }
+    return left;
+  }
+
+  private parseAnd(): ASTNode {
+    let left = this.parseUnary();
+    // AND is implicit: keep consuming while the next token starts a unary
+    while (true) {
+      const t = this.peek();
+      if (!t) break;
+      if (t.kind === 'RPAREN' || t.kind === 'OR') break;
+      // If next token logically could start another clause, combine as AND
+      const next = this.parseUnary();
+      const pos: Position = { start: (left as any).pos.start, end: (next as any).pos.end };
+      if (left.type === 'And') {
+        left = { type: 'And', children: [...left.children, next], pos };
+      } else {
+        left = { type: 'And', children: [left, next], pos };
+      }
+    }
+    return left;
+  }
+
+  private parseUnary(): ASTNode {
+    const t = this.peek();
+    if (!t) {
+      // empty query -> empty group
+      return { type: 'Group', child: null, pos: { start: 0, end: 0 } };
+    }
+    if (t.kind === 'MINUS') {
+      const neg = this.tryParseNegation();
+      if (neg) return neg;
+    }
+    if (t.kind === 'LPAREN') {
+      const start = t.pos.start; this.eat('LPAREN');
+      const inner = this.peek()?.kind === 'RPAREN' ? null : this.parseOr();
+      const endTok = this.eat('RPAREN');
+      const end = endTok ? endTok.pos.end : (inner as any)?.pos.end ?? start + 1;
+      return { type: 'Group', child: inner!, pos: { start, end } };
+    }
+    // Standalone '~' is treated as a literal elsewhere; no special handling here
+    return this.parseTerm();
+  }
+
+  /**
+   * Simplified '-' handling:
+   * - If input starts with '-', negate the following unary expression.
+   * - Lone '-' (no following token) is treated as a literal term "-".
+   */
+  private tryParseNegation(): ASTNode | null {
+    const t = this.peek();
+    if (!t || t.kind !== 'MINUS') return null;
+    const minusTok = this.eat('MINUS')!;
+    const next = this.peek();
+  
+    // Lone '-' → literal term
+    if (!next) {
+      return {
+        type: 'Term',
+        field: undefined,
+        value: '-',
+        phrase: false,
+        fuzzy: false,
+        regex: null,
+        pos: { start: minusTok.pos.start, end: minusTok.pos.end },
+      } as TermNode;
+    }
+  
+    // Otherwise, '-' negates the next unary expression (covers -val, -key:val, -"phrase", -key:"phrase", -( ... ), -/re/, -~, --dash, etc.)
+    const child = this.parseUnary();
+    return {
+      type: 'Not',
+      child,
+      pos: { start: minusTok.pos.start, end: (child as any).pos.end },
+    } as NotNode;
+  }
+
+  private parseTerm(): TermNode | FieldGroupNode {
+    // Consume first token of the term
+    const startTok = this.peek();
+    if (!startTok) throw new Error('Unexpected end of input while parsing term');
+    let first = this.eat();
+    if (!first) throw new Error('Unexpected end of input');
+
+    // Centralized resolution of field and value
+    const { field, valueTok, isBareTildeLiteral, startTok: startForPos, valueIsGroup, groupPosStart } = this.resolveFieldAndValue(first);
+    if (valueIsGroup) {
+      const lp = this.eat('LPAREN');
+      const inner = this.peek()?.kind === 'RPAREN' ? null : this.parseOr();
+      const rp = this.eat('RPAREN');
+      const startPos = (startForPos as any).pos.start;
+      const endPos = rp ? rp.pos.end : (inner as any)?.pos?.end ?? (lp?.pos.end ?? (groupPosStart ?? startPos));
+      return {
+        type: 'FieldGroup',
+        field: field ?? '',
+        child: inner,
+        pos: { start: startPos, end: endPos },
+      } as FieldGroupNode;
+    }
+
+    // Map value token → raw / phrase / regex
+    const v = this.coerceValueFromToken(valueTok);
+    let raw = v.raw;
+    let phrase = v.phrase;
+    let regexInfo: RegexInfo | null = v.regexInfo;
+
+    // Fuzzy operator handling (suffix '~' or adjacent TILDE token)
+    const fuzzyRes = this.parseFuzzyOperator(raw, valueTok, regexInfo, isBareTildeLiteral);
+    raw = fuzzyRes.raw;
+    const fuzzy = fuzzyRes.fuzzy;
+    let endPos = fuzzyRes.endPos;
+
+    if (field && field.toLowerCase() === 'tag' && !phrase && !regexInfo && raw.startsWith('#') && raw.length > 1) {
+      raw = raw.slice(1);
+    }
+
+    ({ raw, phrase } = normalizeSpecialField(field, raw, phrase));
+
+    // If phrase is empty and fuzzy is true → set no-match regex (preserve fuzzy flag)
+    if (phrase && raw === '' && fuzzy) {
+      regexInfo = noMatchRegex();
+    }
+
+    // Default end position: value token end (if fuzzy didn't extend it)
+    if (!endPos) endPos = (valueTok as any).pos?.end ?? (startForPos as any).pos.end;
+
+    dbgParse('parseTerm, term parsed:', { field, raw, phrase, fuzzy, regexInfo });
+
+    return {
+      type: 'Term',
+      field,
+      value: raw,
+      phrase,
+      fuzzy,
+      regex: regexInfo,
+      pos: { start: (startForPos as any).pos.start, end: endPos },
+    } as TermNode;
+  }
+}
+
+// Public API
+export function parseQuery(input: string): ASTNode {
+  dbgParse('parseQuery, input:', input);
+
+  // 1) Pre-validate: if invalid, quietly return an empty AST (no toasts)
+  const v = validateQuerySyntax(input);
+  dbgParse('parseQuery, validation result:', v);
+  if (!(v as any).ok) {
+    return { type: 'Group', child: null, pos: { start: 0, end: 0 } } as GroupNode;
+  }
+
+  const toks = tokenize(input);
+  dbgParse('parseQuery, tokens:', toks);
+  const p = new Parser(toks, input);
+  const ast = p.parse();
+  dbgParse('parseQuery, AST output:', j(ast));
+  return ast;
+}
+
+// ————————————————————————————————————————————————————————————
+// Helpers for debugging / testing
+// ————————————————————————————————————————————————————————————
+
+export function astToString(node: ASTNode): string {
+  dbgParse('astToString, node:', node);
+  switch (node.type) {
+    case 'Term': {
+      const f = node.field ? `${node.field}:` : '';
+      // If it's a true regex node (and not the fuzzy-literal case), print its raw regex.
+      const v = node.regex
+        ? node.regex.raw
+        : (node.phrase ? `"${node.value}"` : node.value);
+      const tilde = node.fuzzy ? '~' : '';
+      return `${f}${v}${tilde}`;
+    }
+    case 'Not':
+      return `-( ${astToString(node.child)} )`;
+    case 'And':
+      return node.children.map(astToString).join(' AND ');
+    case 'Or':
+      return `(${node.children.map(astToString).join(' OR ')})`;
+    case 'Group':
+      return `( ${node.child ? astToString(node.child) : ''} )`;
+    case 'FieldGroup':
+      return `${node.field}:(${node.child ? astToString(node.child) : ''})`;
+  }
+}
+
+// Quick sanity checks (remove or guard behind NODE_ENV in production)
+// Example:
+// console.log(JSON.stringify(parseQuery('(term1 OR -term2) term3'), null, 2));
+// console.log(astToString(parseQuery('tag:JDex coat~ -serious title:"Hello Kitty"~')));
+
+// const debugAST = parseQuery("title:/.*intro/");
+// console.log(JSON.stringify(debugAST, null, 2));

--- a/src/utils/search/search.ts
+++ b/src/utils/search/search.ts
@@ -1,0 +1,100 @@
+import { Media } from "../interfaces";
+import { Note } from "../../api/vault/notes/notes.types";
+import { SearchNotePreferences } from "../preferences";
+import { getPreferenceValues } from "@raycast/api";
+import { parseQuery } from "./parser";
+import { evaluateQueryAST } from "./evaluator";
+import { dbgSearch, j } from "../../api/logger/debugger";
+
+const pref = getPreferenceValues<SearchNotePreferences>();
+
+export function searchFunction(notes: Note[], searchQuery: string): Note[] {
+  const query = (searchQuery ?? "").trim();
+  if (!query) return notes;
+
+  // 1) Parse to AST safely
+  let ast;
+  try {
+    ast = parseQuery(query);
+  } catch {
+    return notes; // graceful fallback on malformed query
+  }
+
+  // TEMP DEBUG: Find and log a specific note for debugging (scoped via dbgSearch)
+  const foundNote = notes.find((n) => n.title === "<note_title>");
+  dbgSearch("Found specific note", foundNote ? j(foundNote, 0) : "NOT FOUND");
+
+  // 2) Build docs: expose all note fields (custom props included) + stable id
+  const docs = notes.map((n) => ({
+    id: n.path,   // stable identifier for evaluator + mapping back
+    ...n,         // exposes custom/frontmatter keys (e.g., index, status, locations, etc.)
+  }));
+
+  // TEMP DEBUG: Inspect a specific note before evaluation (scoped via dbgSearch)
+  const TARGET = "<note_title>";
+  const sample = docs.find((d) => String(d.id).includes(TARGET));
+  dbgSearch("Target doc sample", sample ? {
+    id: sample?.id,
+    title: (sample as any)?.title,
+    path: (sample as any)?.path,
+    tags: (sample as any)?.tags,
+    aliases: (sample as any)?.aliases,
+  } : "NOT FOUND in docs");
+
+  // 3) Evaluate (Fuse only kicks in for terms with ~; content is only used when the term targets it)
+  //console.log("DOCS", JSON.stringify(docs.slice(0, 5), null, 2));
+  const { hits } = evaluateQueryAST(ast, docs, {
+    defaultFields: Array.isArray(pref.userDefinedSearchScope) && pref.userDefinedSearchScope.length
+      ? (pref.userDefinedSearchScope as unknown as string[])
+      : (typeof pref.userDefinedSearchScope === "string" && pref.userDefinedSearchScope.trim().length > 0)
+        ? [pref.userDefinedSearchScope]
+        : Array.isArray(pref.prefSearchScope)
+          ? (pref.prefSearchScope as unknown as string[])
+          : [pref.prefSearchScope || "title"],
+
+    fieldMap: {
+      // Aliases / reserved behavior
+      file: (d: any) => d.title,
+      anyname: (d: any) => [d.title, ...(d.aliases ?? [])],
+      // Optional: keep tag mapping explicit; otherwise the spread already exposes d.tags
+      tag: (d: any) => d.tags,
+      // Heavy fields (Fuse will only touch when a fuzzy term targets these fields)
+      full: (d: any) => [d.content, d.path].filter(Boolean),
+    },
+
+    // Only applied to terms carrying ~
+    fuzzy: { threshold: 0.35, minMatchCharLength: 2 },
+  });
+
+  // 4) Map back to Notes in ranked order
+  const byId = new Map(notes.map((n) => [n.path, n] as const));
+  return hits
+    .map((h) => byId.get(h.id))
+    .filter((n): n is Note => Boolean(n));
+}
+
+/**
+ * Filters a list of media according to the input search string. If the input is empty, all media is returned. It will match the medias title, path and all notes mentioning the media.
+ *
+ * @param vault - Vault to search
+ * @param input - Search input
+ * @returns - A list of media filtered according to the input search string
+ */
+export function filterMedia(mediaList: Media[], input: string, notes: Note[]) {
+  if (input?.length === 0) {
+    return mediaList;
+  }
+
+  input = input.toLowerCase();
+
+  notes = notes.filter((note) => note.title.toLowerCase().includes(input));
+
+  return mediaList.filter((media) => {
+    return (
+      media.title.toLowerCase().includes(input) ||
+      media.path.toLowerCase().includes(input) ||
+      // Filter media that is mentioned in a note which has the searched title
+      notes.some((note) => note.content.includes(media.title))
+    );
+  });
+}

--- a/src/utils/search/types.ts
+++ b/src/utils/search/types.ts
@@ -1,0 +1,19 @@
+// src/utils/search/types.ts
+
+export type Position = { start: number; end: number };
+
+export type RegexInfo = { pattern: string; flags: string; raw: string };
+
+// Lexer tokens
+export type Token =
+  | { kind: 'LPAREN'; pos: Position }
+  | { kind: 'RPAREN'; pos: Position }
+  | { kind: 'AND'; pos: Position }
+  | { kind: 'OR'; pos: Position }
+  | { kind: 'MINUS'; pos: Position } // unary NOT
+  | { kind: 'COLON'; pos: Position }
+  | { kind: 'TERM'; value: string; pos: Position }
+  | { kind: 'PHRASE'; value: string; pos: Position }
+  | { kind: 'TILDE'; pos: Position }
+  | { kind: 'REGEX'; pattern: string; flags: string; raw: string; pos: Position }
+  | { kind: 'WS'; pos: Position };

--- a/src/utils/search/validator.ts
+++ b/src/utils/search/validator.ts
@@ -1,0 +1,233 @@
+/*
+ * Search query syntax validator (pre-parse)
+ *
+ * Rules enforced (structural only):
+ * - Balanced parentheses
+ * - AND/OR not dangling and not doubled
+ * - Regex literals `/.../flags` must close (deep regex validation is deferred)
+ */
+
+export type ValidationIssue = {
+  index: number;
+  length?: number;
+  code:
+  | 'UNBALANCED_PARENS'
+  | 'DANGLING_OPERATOR'
+  | 'UNFINISHED_REGEX';
+};
+
+export type ValidationResult = { ok: true } | { ok: false; issue: ValidationIssue };
+
+// Character helpers ---------------------------------------------------------
+function isWhitespace(ch: string) {
+  return ch === ' ' || ch === '\n' || ch === '\t' || ch === '\r';
+}
+
+function isSpecial(ch: string) {
+  return ch === '(' || ch === ')' || ch === '-' || ch === '~' || ch === ':';
+}
+
+function isTermChar(ch: string) {
+  return !isWhitespace(ch) && !isSpecial(ch) && ch !== '"' && ch !== '/';
+}
+
+function startsOperator(input: string, i: number) {
+  // AND / OR, case-insensitive, must be bounded by separators
+  const prev = i > 0 ? input[i - 1] : undefined;
+  const isPrevBoundary =
+    prev === undefined ||
+    isWhitespace(prev) ||
+    prev === '(' ||
+    prev === ')';
+  if (!isPrevBoundary) return null;
+
+  const rest = input.slice(i);
+  if (/^(AND)(?![A-Za-z0-9_])/.test(rest)) return { op: 'AND', len: 3 } as const;
+  if (/^(OR)(?![A-Za-z0-9_])/.test(rest)) return { op: 'OR', len: 2 } as const;
+  if (/^(and)(?![A-Za-z0-9_])/.test(rest)) return { op: 'AND', len: 3 } as const;
+  if (/^(or)(?![A-Za-z0-9_])/.test(rest)) return { op: 'OR', len: 2 } as const;
+  return null;
+}
+
+// Lightweight quoted reader used only for structural validation. If a closing quote
+// is found with standard escapes (\"), returns the index after the closing quote;
+// otherwise returns null and the caller may consume a single '"' leniently.
+function readQuotedLite(input: string, i: number): number | null {
+  let k = i + 1;
+  let escaped = false;
+  while (k < input.length) {
+    const ch = input[k];
+    if (escaped) { escaped = false; k++; continue; }
+    if (ch === '\\') { escaped = true; k++; continue; }
+    if (ch === '"') { return k + 1; }
+    k++;
+  }
+  return null;
+}
+
+// Skip consecutive TERM characters (including simple escapes) used in validation only
+function skipTerm(input: string, i: number): number {
+  while (i < input.length) {
+    const c = input[i];
+    if (isTermChar(c)) { i++; continue; }
+    if (c === '\\' && i + 1 < input.length) { i += 2; continue; }
+    break;
+  }
+  return i;
+}
+
+// Read a regex literal starting at index i (where input[i] === '/')
+function readRegex(input: string, i: number): { end: number } | null {
+  let k = i + 1;
+  let escaped = false;
+  while (k < input.length) {
+    const ch = input[k];
+    if (escaped) {
+      escaped = false;
+      k++;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = true;
+      k++;
+      continue;
+    }
+    if (ch === '/') {
+      // consume optional flags [a-z]*
+      k++;
+      while (k < input.length && /[a-z]/i.test(input[k])) k++;
+      return { end: k };
+    }
+    k++;
+  }
+  return null; // unfinished
+}
+
+// NOTE: This validator is structural-only; token semantics (quotes/fields/fuzzy) are handled by lexer/parser.
+// Main validator ------------------------------------------------------------
+export function validateQuerySyntax(input: string): ValidationResult {
+  const n = input.length;
+  let i = 0;
+  let parenDepth = 0;
+  let lastWasValue = false; // last token was a VALUE (TERM/PHRASE/REGEX)
+  let lastWasOperator = false; // last token was AND/OR
+
+  // Skip initial whitespace
+  while (i < n && isWhitespace(input[i])) i++;
+
+  while (i < n) {
+    const ch = input[i];
+
+    // Whitespace → separator
+    if (isWhitespace(ch)) {
+      i++;
+      continue;
+    }
+
+    // Parentheses
+    if (ch === '(') {
+      parenDepth++;
+      lastWasValue = false;
+      lastWasOperator = false;
+      i++;
+      continue;
+    }
+    if (ch === ')') {
+      if (parenDepth === 0) {
+        return {
+          ok: false,
+          issue: {
+            index: i,
+            code: 'UNBALANCED_PARENS',
+          },
+        };
+      }
+      parenDepth--;
+      lastWasValue = true;
+      lastWasOperator = false;
+      i++;
+      continue;
+    }
+
+    // Operators AND/OR
+    const op = startsOperator(input, i);
+    if (op) {
+      // operator must be between two values/clauses
+      if (lastWasOperator || !lastWasValue) {
+        return {
+          ok: false,
+          issue: {
+            index: i,
+            length: op.len,
+            code: 'DANGLING_OPERATOR',
+          },
+        };
+      }
+      i += op.len;
+      lastWasOperator = true;
+      lastWasValue = false;
+      continue;
+    }
+
+    // Quote character — lenient: consume and treat as part of a value for validation purposes.
+    // The tokenizer/parser will decide if this becomes a PHRASE or a literal depending on closure.
+    if (ch === '"') {
+      const end = readQuotedLite(input, i);
+      i = end ?? (i + 1); // if unfinished, consume one char leniently
+      lastWasValue = true; // a phrase counts as a VALUE for operator placement
+      lastWasOperator = false;
+      continue;
+    }
+
+    // Regex
+    if (ch === '/') {
+      const rg = readRegex(input, i);
+      if (!rg) {
+        return {
+          ok: false,
+          issue: {
+            index: i,
+            code: 'UNFINISHED_REGEX',
+          },
+        };
+      }
+      i = rg.end;
+      lastWasValue = true;
+      lastWasOperator = false;
+      continue;
+    }
+
+    // TERM (bare)
+    if (isTermChar(ch)) {
+      i = skipTerm(input, i);
+      lastWasValue = true;
+      lastWasOperator = false;
+      continue;
+    }
+
+    // Fallback: advance
+    i++;
+  }
+
+  if (parenDepth !== 0) {
+    return {
+      ok: false,
+      issue: {
+        index: n,
+        code: 'UNBALANCED_PARENS',
+      },
+    };
+  }
+
+  if (lastWasOperator) {
+    return {
+      ok: false,
+      issue: {
+        index: n,
+        code: 'DANGLING_OPERATOR',
+      },
+    };
+  }
+
+  return { ok: true };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "display": "Node 16",
   "include": ["src/**/*"],
   "compilerOptions": {
+    "types": ["vitest/globals", "node"],
     "lib": ["es2020", "ES2021.String"],
     "module": "commonjs",
     "target": "es2020",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,9 @@ import path from "path";
 export default defineConfig({
   test: {
     environment: "node",
+    globals: true, // <-- add this so describe/it/expect are recognized
+    include: ["src/**/*.{spec,test}.{ts,tsx}"], // <-- tells Vitest where to look for test files
+    clearMocks: true,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
# New Search Syntax, Sorting Options & JD Enhancements

This PR extends [#114](https://github.com/marcjulianschwarz/obsidian-raycast/pull/114).

It introduces an Obsidian-style search syntax, replaces the tag picker with a sorting picker, and adds several [Johnny.Decimal](https://johnnydecimal.com/) (JD) enhancements, plus other improvements for greater flexibility.

## **Highlights**

- **Search**
  - Fielded terms (`tag:foo`, `path:"notes/"`, etc.)
  - Quotes, grouping, boolean (`AND`/`OR`), negation (`-`)
  - Fuzzy suffix (`term~`, `"phrase"~`)
  - Regex (`/pattern/flags`)
  - Clear rules for field presence and always-present virtual fields
  - Unit tests for the search pipeline (Vitest)
  - **Docs:** added `search/README` with full query syntax rules
- **Sorting**
  - Replaced tag picker with sort order picker:
    - File name (A↔Z)
    - Created time (new↔old)
    - Modified time (new↔old)
- **Create Note / JD**
  - Extra JD fields (toggle in settings)
  - User-defined JDex Title separator
  - JD-specific tagging option
- **Settings**
  - Default sort order
  - Default search scope (`file`, `anyname`, `full`)
    - Optional: User-defined default scope text
  - Default YAML keys on note creation
  - Global inclusion settings harmonized with exclusions
- **Commands**
  - Prefill option for Search Note
  - Bookmarked Notes generalized to user-defined **Important Notes**
    - Defaults to filtering bookmarked notes