### PR TITLE
feat(open-vault): show vault path, add nickname support, and fix a bug where a wrong vault was opened

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -30,12 +30,16 @@ Last time verified all: 2025-12-11 (macOS)
 
 ## Vault Selection
 
-Nearly every command has a vault selection that either moves to the next "action/page" directly when there is only one vault in Obsidian or shows a selection when there are multiple vaults.
+Nearly every command has a vault selection that either moves to the next "action/page" directly when there is only one vault in Obsidian or shows a selection when there are multiple vaults. Each vault displays its full file system path as a subtitle for disambiguation.
+
+Vault nicknames can be set to show a custom display name instead of the vault's folder name. Nicknames are stored in Raycast's local storage (via `useVaultNicknames` in `src/utils/hooks.ts`) and apply across all vault lists. The vault folder name is never changed — it continues to be used internally for Obsidian URIs.
 
 - [ ] actions
   - [ ] Select Vault
   - [ ] Show in Finder
   - [ ] Copy File Path (opt + shift + c)
+  - [ ] Set Nickname (cmd + r) — opens a form pre-filled with the current nickname if one exists; saving replaces it
+  - [ ] Clear Nickname (cmd + d) — only shown when a nickname is already set; restores the folder name
 
 ## Notes List
 
@@ -102,6 +106,8 @@ Many commands use a note list.
   - [ ] Open Vault
   - [ ] Show in Finder
   - [ ] Copy File Path (opt + shift + c)
+  - [ ] Set Nickname (cmd + r) — see vault selection
+  - [ ] Clear Nickname (cmd + d) — see vault selection
 
 ## Random Note Command
 

--- a/src/components/VaultSelection.tsx
+++ b/src/components/VaultSelection.tsx
@@ -9,6 +9,7 @@ export function VaultSelection(props: { vaults: ObsidianVault[]; target: (vault:
       {vaults?.map((vault) => (
         <List.Item
           title={vault.name}
+          subtitle={vault.path}
           key={vault.key}
           actions={
             <ActionPanel>

--- a/src/components/VaultSelection.tsx
+++ b/src/components/VaultSelection.tsx
@@ -1,14 +1,17 @@
 import { ObsidianVault } from "@/obsidian";
 import { Action, ActionPanel, List } from "@raycast/api";
-import { ShowVaultInFinderAction, CopyVaultPathAction } from "../utils/actions";
+import { ShowVaultInFinderAction, CopyVaultPathAction, SetVaultNicknameAction, ClearVaultNicknameAction } from "../utils/actions";
+import { useVaultNicknames } from "../utils/hooks";
 
 export function VaultSelection(props: { vaults: ObsidianVault[]; target: (vault: ObsidianVault) => React.ReactNode }) {
   const { vaults, target } = props;
+  const { nicknames, setNickname, clearNickname } = useVaultNicknames();
+
   return (
     <List>
       {vaults?.map((vault) => (
         <List.Item
-          title={vault.name}
+          title={nicknames[vault.path] ??vault.name}
           subtitle={vault.path}
           key={vault.key}
           actions={
@@ -16,6 +19,8 @@ export function VaultSelection(props: { vaults: ObsidianVault[]; target: (vault:
               <Action.Push title="Select Vault" target={target(vault)} />
               <ShowVaultInFinderAction vault={vault} />
               <CopyVaultPathAction vault={vault} />
+              <SetVaultNicknameAction vault={vault} currentNickname={nicknames[vault.path]} onSet={setNickname} />
+              {nicknames[vault.path] && <ClearVaultNicknameAction vault={vault} onClear={clearNickname} />}
             </ActionPanel>
           }
         />

--- a/src/obsidian/internal/obsidian.ts
+++ b/src/obsidian/internal/obsidian.ts
@@ -47,10 +47,15 @@ export async function getVaultsFromObsidianJson(): Promise<ObsidianVault[]> {
 
   try {
     const obsidianJson = JSON.parse(await fsAsync.readFile(obsidianJsonPath, "utf8")) as ObsidianJSON;
-    return Object.values(obsidianJson.vaults).map(({ path }) => ({
+    // Use Object.entries() (not Object.values()) so we capture the vault's
+    // hash key alongside its data. That hash is the stable ID Obsidian uses
+    // internally and is what we include in obsidian:// URIs to avoid
+    // ambiguity when multiple vaults share the same folder name.
+    return Object.entries(obsidianJson.vaults).map(([id, { path }]) => ({
       name: getVaultNameFromPath(path) ?? "invalid vault name",
       key: path,
       path,
+      id,
     }));
   } catch (e) {
     return [];
@@ -119,7 +124,12 @@ export type ObsidianTarget =
 export function getObsidianTarget(target: ObsidianTarget) {
   switch (target.type) {
     case ObsidianTargetType.OpenVault: {
-      return ObsidianTargetType.OpenVault + encodeURIComponent(target.vault.name);
+      // Prefer the Obsidian-internal hash ID when available — it uniquely
+      // identifies the vault even when several vaults share the same folder
+      // name. Vaults sourced from Raycast preferences lack an ID, so we fall
+      // back to the vault name in that case.
+      const vaultIdentifier = target.vault.id ?? target.vault.name;
+      return ObsidianTargetType.OpenVault + encodeURIComponent(vaultIdentifier);
     }
     case ObsidianTargetType.OpenPath: {
       return ObsidianTargetType.OpenPath + encodeURIComponent(target.path);

--- a/src/obsidian/internal/vault.ts
+++ b/src/obsidian/internal/vault.ts
@@ -10,10 +10,30 @@ import { Note } from "./notes";
 
 const logger: Logger = new Logger("Vaults");
 
+/**
+ * Represents an Obsidian vault discovered either from Raycast preferences or
+ * from Obsidian's own `obsidian.json` registry.
+ *
+ * @remarks
+ * The `id` field is the opaque hash key Obsidian assigns to each vault in
+ * `obsidian.json` (e.g. `"a3f9c1b2d8e4f0a1"`).  When present it should be
+ * preferred over `name` when constructing `obsidian://` URIs because it
+ * uniquely identifies the vault even when multiple vaults share the same
+ * folder name.  Vaults sourced from Raycast preferences have no Obsidian-
+ * assigned ID and will leave this field `undefined`.
+ */
 export interface ObsidianVault {
+  /** Human-readable name derived from the vault's folder basename. */
   name: string;
+  /** Stable React list key — always set to the vault's absolute file-system path. */
   key: string;
+  /** Absolute file-system path to the vault root directory. */
   path: string;
+  /**
+   * Obsidian-internal hash ID from `obsidian.json`.
+   * Only present for vaults discovered via {@link getVaultsFromObsidianJson}.
+   */
+  id?: string;
 }
 
 /** Gets a list of folders that are ignored by the user inside of Obsidian */

--- a/src/openVaultCommand.tsx
+++ b/src/openVaultCommand.tsx
@@ -2,11 +2,12 @@ import { Action, ActionPanel, closeMainWindow, List, open, popToRoot, Icon } fro
 
 import { NoVaultFoundMessage } from "./components/Notifications/NoVaultFoundMessage";
 import { Obsidian, ObsidianTargetType } from "@/obsidian";
-import { ShowVaultInFinderAction, CopyVaultPathAction } from "./utils/actions";
-import { useObsidianVaults } from "./utils/hooks";
+import { ShowVaultInFinderAction, CopyVaultPathAction, SetVaultNicknameAction, ClearVaultNicknameAction } from "./utils/actions";
+import { useObsidianVaults, useVaultNicknames } from "./utils/hooks";
 
 export default function Command() {
   const { ready, vaults } = useObsidianVaults();
+  const { nicknames, setNickname, clearNickname } = useVaultNicknames();
 
   if (vaults.length === 1) {
     open(Obsidian.getTarget({ type: ObsidianTargetType.OpenVault, vault: vaults[0] }));
@@ -28,7 +29,7 @@ export default function Command() {
       <List isLoading={!ready}>
         {vaults?.map((vault) => (
           <List.Item
-            title={vault.name}
+            title={nicknames[vault.path] ?? vault.name}
             subtitle={vault.path}
             key={vault.key}
             actions={
@@ -40,6 +41,8 @@ export default function Command() {
                 />
                 <ShowVaultInFinderAction vault={vault} />
                 <CopyVaultPathAction vault={vault} />
+                <SetVaultNicknameAction vault={vault} currentNickname={nicknames[vault.path]} onSet={setNickname} />
+                {nicknames[vault.path] && <ClearVaultNicknameAction vault={vault} onClear={clearNickname} />}
               </ActionPanel>
             }
           />

--- a/src/openVaultCommand.tsx
+++ b/src/openVaultCommand.tsx
@@ -29,6 +29,7 @@ export default function Command() {
         {vaults?.map((vault) => (
           <List.Item
             title={vault.name}
+            subtitle={vault.path}
             key={vault.key}
             actions={
               <ActionPanel>

--- a/src/utils/actions.tsx
+++ b/src/utils/actions.tsx
@@ -311,7 +311,9 @@ export function CopyVaultPathAction(props: { vault: ObsidianVault }) {
 }
 
 /**
- * Form to set vault nickname
+ * Single-field form for entering or editing a vault nickname.
+ * Pre-filled with the current nickname when one exists.
+ * Submitting an empty or whitespace-only value is a no-op.
  */
 function SetVaultNicknameForm(props: {
   vault: ObsidianVault;
@@ -350,7 +352,8 @@ function SetVaultNicknameForm(props: {
 
 
 /**
- * Action to set vault nickname
+ * Pushes {@link SetVaultNicknameForm} to set or update the display name for a vault.
+ * Shortcut: `cmd + r`.
  */
 export function SetVaultNicknameAction(props: {
   vault: ObsidianVault;
@@ -369,7 +372,8 @@ export function SetVaultNicknameAction(props: {
 }
 
 /**
- * Action to clear vault nickname
+ * Clears the nickname for a vault, restoring its folder name as the display title.
+ * Only rendered when the vault already has a nickname set. Shortcut: `cmd + d`.
  */
 export function ClearVaultNicknameAction(props: {
   vault: ObsidianVault;

--- a/src/utils/actions.tsx
+++ b/src/utils/actions.tsx
@@ -3,10 +3,12 @@ import {
   ActionPanel,
   Color,
   confirmAlert,
+  Form,
   getDefaultApplication,
   getPreferenceValues,
   Icon,
   List,
+  useNavigation,
 } from "@raycast/api";
 import React, { useEffect, useState } from "react";
 import fs from "fs";
@@ -19,7 +21,7 @@ import { updateNoteInCache, deleteNoteFromCache } from "../api/cache/cache.servi
 import { Logger } from "../api/logger/logger.service";
 import { Note, NoteWithContent, Obsidian, ObsidianTargetType, ObsidianVault, Vault } from "@/obsidian";
 import { getCodeBlocks } from "./utils";
-import { useVaultPluginCheck } from "./hooks";
+import { useVaultPluginCheck, useVaultNicknames } from "./hooks";
 import { appendSelectedTextTo } from "@/api/append-note";
 
 const logger = new Logger("Actions");
@@ -304,6 +306,82 @@ export function CopyVaultPathAction(props: { vault: ObsidianVault }) {
       title="Copy File Path"
       content={vault.path}
       shortcut={{ modifiers: ["opt", "shift"], key: "c" }}
+    />
+  );
+}
+
+/**
+ * Form to set vault nickname
+ */
+function SetVaultNicknameForm(props: {
+  vault: ObsidianVault;
+  currentNickname: string | undefined;
+  onSet: (vaultPath: string, nickname: string) => Promise<void>;
+}) {
+  const { vault, currentNickname, onSet } = props;
+  const { pop } = useNavigation();
+
+  async function handleSubmit(values: { nickname: string }) {
+    if (values.nickname.trim()) {
+      await onSet(vault.path, values.nickname);
+    }
+    pop();
+  }
+
+  return (
+    <Form
+      navigationTitle="Set Vault Nickname"
+      actions={
+        <ActionPanel>
+          <Action.SubmitForm title="Save Nickname" onSubmit={handleSubmit} />
+        </ActionPanel>
+      }
+    >
+      <Form.TextField
+        id="nickname"
+        title="Nickname"
+        placeholder={vault.name}
+        defaultValue={currentNickname ?? ""}
+        info="Shown instead of the vault folder name in all vault lists"
+      />
+    </Form>
+  );
+}
+
+
+/**
+ * Action to set vault nickname
+ */
+export function SetVaultNicknameAction(props: {
+  vault: ObsidianVault;
+  currentNickname: string | undefined;
+  onSet: (vaultPath: string, nickname: string) => Promise<void>;
+}) {
+  const { vault, currentNickname, onSet } = props;
+  return (
+    <Action.Push
+      title="Set Nickname"
+      icon={Icon.Pencil}
+      shortcut={{ modifiers: ["cmd"], key: "r" }}
+      target={<SetVaultNicknameForm vault={vault} currentNickname={currentNickname} onSet={onSet} />}
+    />
+  );
+}
+
+/**
+ * Action to clear vault nickname
+ */
+export function ClearVaultNicknameAction(props: {
+  vault: ObsidianVault;
+  onClear: (vaultPath: string) => Promise<void>;
+}) {
+  const { vault, onClear } = props;
+  return (
+    <Action
+      title="Clear Nickname"
+      icon={Icon.XMarkCircle}
+      shortcut={{ modifiers: ["cmd"], key: "d" }}
+      onAction={() => onClear(vault.path)}
     />
   );
 }

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -221,17 +221,23 @@ export function useVaultPluginCheck(params: {
   }, [params.vaults.map((v) => v.path).join(","), params.communityPlugins?.join(","), params.corePlugins?.join(",")]);
 }
 
+/** LocalStorage key for the vault nicknames map. */
+const VAULT_NICKNAME_KEY = "vault-nicknames";
+
 /**
- * Sets / clears vault nickname
- * Nicknames are stored in local storage
+ * Manages custom display names for vaults, persisted in Raycast LocalStorage.
+ *
+ * Nicknames are stored as a JSON map keyed by vault path. When a nickname is
+ * set, it replaces the vault folder name in all vault lists. The vault's actual
+ * folder name (used in Obsidian URIs) is never affected.
+ *
+ * @returns `nicknames` — map of vault path to nickname; `setNickname` — adds or
+ * overwrites a nickname; `clearNickname` — removes a nickname, restoring the
+ * folder name.
  */
-
-const VAULT_NICKNAME_KEY = "vault-nicknames"; // LocalStorage key for vault nicknames
-
 export function useVaultNicknames() {
   const [nicknames, setNicknames] = useState<Record<string, string>>({});
 
-  // If present, extract existing vault nicknames from local storage on mount
   useEffect(() => {
     LocalStorage.getItem<string>(VAULT_NICKNAME_KEY).then((stored) => {
       if (stored) {
@@ -241,19 +247,19 @@ export function useVaultNicknames() {
           setNicknames({});
         }
       }
-    })
+    });
   }, []);
 
-  // Sets vault nickname
+  /** Adds or overwrites the nickname for the given vault path. */
   async function setNickname(vaultPath: string, nickname: string): Promise<void> {
     const updated = { ...nicknames, [vaultPath]: nickname.trim() };
     setNicknames(updated);
     await LocalStorage.setItem(VAULT_NICKNAME_KEY, JSON.stringify(updated));
   }
 
-  // Clears vault nickname
+  /** Removes the nickname for the given vault path, restoring the folder name. */
   async function clearNickname(vaultPath: string): Promise<void> {
-    const updated = { ...nicknames }
+    const updated = { ...nicknames };
     delete updated[vaultPath];
     setNicknames(updated);
     await LocalStorage.setItem(VAULT_NICKNAME_KEY, JSON.stringify(updated));

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,4 +1,4 @@
-import { getPreferenceValues, showToast, Toast } from "@raycast/api";
+import { getPreferenceValues, LocalStorage, showToast, Toast } from "@raycast/api";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { MediaState } from "./interfaces";
 import { filterContent, sortByAlphabet } from "./utils";
@@ -219,4 +219,45 @@ export function useVaultPluginCheck(params: {
 
     return resultObject;
   }, [params.vaults.map((v) => v.path).join(","), params.communityPlugins?.join(","), params.corePlugins?.join(",")]);
+}
+
+/**
+ * Sets / clears vault nickname
+ * Nicknames are stored in local storage
+ */
+
+const VAULT_NICKNAME_KEY = "vault-nicknames"; // LocalStorage key for vault nicknames
+
+export function useVaultNicknames() {
+  const [nicknames, setNicknames] = useState<Record<string, string>>({});
+
+  // If present, extract existing vault nicknames from local storage on mount
+  useEffect(() => {
+    LocalStorage.getItem<string>(VAULT_NICKNAME_KEY).then((stored) => {
+      if (stored) {
+        try {
+          setNicknames(JSON.parse(stored));
+        } catch {
+          setNicknames({});
+        }
+      }
+    })
+  }, []);
+
+  // Sets vault nickname
+  async function setNickname(vaultPath: string, nickname: string): Promise<void> {
+    const updated = { ...nicknames, [vaultPath]: nickname.trim() };
+    setNicknames(updated);
+    await LocalStorage.setItem(VAULT_NICKNAME_KEY, JSON.stringify(updated));
+  }
+
+  // Clears vault nickname
+  async function clearNickname(vaultPath: string): Promise<void> {
+    const updated = { ...nicknames }
+    delete updated[vaultPath];
+    setNicknames(updated);
+    await LocalStorage.setItem(VAULT_NICKNAME_KEY, JSON.stringify(updated));
+  }
+
+  return { nicknames, setNickname, clearNickname };
 }


### PR DESCRIPTION
## Problem

A) When multiple vaults share the same directory name (e.g. a Docusaurus `docs` folder per project), the Open Vault command and all vault selection screens offer no way to tell them apart. The vault name is always derived from the folder name, which cannot be changed without modifying vault directory.

<img width="833" height="544" alt="vanilla" src="https://github.com/user-attachments/assets/c2a8f78d-8e81-4425-a6c6-404338337009" />

_As we can see, we have three docs vaults, and no way to tell which is which._

B) When multiple vaults share the same directory name (e.g. three vaults all named `docs`), the Open Vault command often opens the wrong one. This is because the obsidian URI is built using vault.name - if there are multiple vaults with the same name, the first one that matches is opened.

## Solution

**1. Vault path as subtitle**
Each vault now displays its full filesystem path alongside its name, making disambiguation possible without any configuration.

**2. Vault nicknames**
Users can assign a custom display name to any vault. When set, the nickname replaces the folder name as the list title while the path remains visible in the subtitle. Nicknames are persisted in Raycast LocalStorage and apply across all vault lists.

<img width="833" height="544" alt="with-nickname" src="https://github.com/user-attachments/assets/ff9f1425-511f-415e-90bc-21d76230ce08" />

Actions added to every vault list item:
- **Set Nickname** (`cmd + r`) — opens a minimal form, pre-filled with the current nickname if one exists
- **Clear Nickname** (`cmd + d`) — only shown when a nickname is set; restores the folder name

<img width="833" height="544" alt="form-view" src="https://github.com/user-attachments/assets/3f8d641e-fba6-4de9-9e38-d5be4ac3acdf" />

_A simple form view for entering the nickname_

The nicknames are purely cosmetic - a way to organize and understand your vaults better within Raycast; they don't persist in any way inside Obsidian.

**3. Fix: open the correct vault when names collide**
The Open Vault command now uses Obsidian's internal vault ID (from obsidian.json) in the URI instead of the vault name. This ensures the correct vault is always opened, even when multiple vaults share the same folder name. If hash ID is unavailable, we fall back to `vault.name`.

## Changes
**Vault Nicknames & Path Display**
- `src/utils/hooks.ts` — new `useVaultNicknames()` hook
- `src/utils/actions.tsx` — new `SetVaultNicknameAction`, `ClearVaultNicknameAction`, `SetVaultNicknameForm`
- `src/openVaultCommand.tsx` — path subtitle + nickname display + actions
- `src/components/VaultSelection.tsx` — path subtitle + nickname display + actions
- `REFERENCE.md` — updated vault selection and open vault command sections

**Vault Opening Logic**
- `ObsidianVault` interface gains an optional `id` field for the Obsidian hash.
- `getVaultsFromObsidianJson` switches from `Object.values()` to `Object.entries()` to capture each vault's hash key alongside its path data.
- `getObsidianTarget` (OpenVault case) now uses `vault.id ?? vault.name`